### PR TITLE
Add generic Postgres client utilities

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -14,4 +14,11 @@
     <packaging>jar</packaging>
     <name>Split Commons</name>
     <description>Postgres utilities and shared components</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/commons/src/main/java/com/split/ai/commons/postgres/BeanUtils.java
+++ b/commons/src/main/java/com/split/ai/commons/postgres/BeanUtils.java
@@ -1,0 +1,23 @@
+package com.split.ai.commons.postgres;
+
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.BeanWrapperImpl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+final class BeanUtils {
+    private BeanUtils() {}
+
+    static Map<String, Object> toMap(Object bean) {
+        BeanWrapper wrapper = new BeanWrapperImpl(bean);
+        Map<String, Object> map = new HashMap<>();
+        for (java.beans.PropertyDescriptor pd : wrapper.getPropertyDescriptors()) {
+            String name = pd.getName();
+            if (!"class".equals(name)) {
+                map.put(name, wrapper.getPropertyValue(name));
+            }
+        }
+        return map;
+    }
+}

--- a/commons/src/main/java/com/split/ai/commons/postgres/PostgresClient.java
+++ b/commons/src/main/java/com/split/ai/commons/postgres/PostgresClient.java
@@ -1,0 +1,24 @@
+package com.split.ai.commons.postgres;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generic client interface for basic Postgres operations.
+ */
+public interface PostgresClient {
+
+    <T> T insert(String tableName, T object);
+
+    <T> int update(String tableName, T object, Map<String, Object> filters);
+
+    <T> int upsert(String tableName, T object, Map<String, Object> filters);
+
+    <T> T findById(String tableName, Object id, Class<T> clazz);
+
+    <T> T find(String tableName, Map<String, Object> filters, Class<T> clazz);
+
+    <T> List<T> findAll(String tableName, Map<String, Object> filters, Class<T> clazz);
+
+    <T> List<T> query(String sql, Map<String, Object> params, Class<T> clazz);
+}

--- a/commons/src/main/java/com/split/ai/commons/postgres/PostgresClientImpl.java
+++ b/commons/src/main/java/com/split/ai/commons/postgres/PostgresClientImpl.java
@@ -1,0 +1,91 @@
+package com.split.ai.commons.postgres;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Default implementation of {@link PostgresClient} using {@link NamedParameterJdbcTemplate}.
+ */
+@Component
+public class PostgresClientImpl implements PostgresClient {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final DataSource dataSource;
+
+    @Autowired
+    public PostgresClientImpl(NamedParameterJdbcTemplate jdbcTemplate, DataSource dataSource) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public <T> T insert(String tableName, T object) {
+        SimpleJdbcInsert insert = new SimpleJdbcInsert(dataSource)
+                .withTableName(tableName)
+                .usingGeneratedKeyColumns("id");
+        Number id = insert.executeAndReturnKey(new BeanPropertySqlParameterSource(object));
+        // attempt to set generated id back on object if property exists
+        try {
+            object.getClass().getMethod("setId", Long.class).invoke(object, id.longValue());
+        } catch (Exception ignored) {
+        }
+        return object;
+    }
+
+    @Override
+    public <T> int update(String tableName, T object, Map<String, Object> filters) {
+        Map<String, Object> values = BeanUtils.toMap(object);
+        String sql = "UPDATE " + tableName + " SET " + QueryUtils.updateAssignments(values)
+                + QueryUtils.whereClause(filters);
+        MapSqlParameterSource source = new MapSqlParameterSource();
+        values.forEach(source::addValue);
+        if (filters != null) {
+            filters.forEach(source::addValue);
+        }
+        return jdbcTemplate.update(sql, source);
+    }
+
+    @Override
+    public <T> int upsert(String tableName, T object, Map<String, Object> filters) {
+        // naive implementation: try update first, if nothing updated then insert
+        int updated = update(tableName, object, filters);
+        if (updated == 0) {
+            insert(tableName, object);
+            return 1;
+        }
+        return updated;
+    }
+
+    @Override
+    public <T> T findById(String tableName, Object id, Class<T> clazz) {
+        String sql = "SELECT * FROM " + tableName + " WHERE id = :id";
+        MapSqlParameterSource source = new MapSqlParameterSource("id", id);
+        return jdbcTemplate.queryForObject(sql, source, BeanPropertyRowMapper.newInstance(clazz));
+    }
+
+    @Override
+    public <T> T find(String tableName, Map<String, Object> filters, Class<T> clazz) {
+        String sql = "SELECT * FROM " + tableName + QueryUtils.whereClause(filters) + " LIMIT 1";
+        return jdbcTemplate.queryForObject(sql, filters, BeanPropertyRowMapper.newInstance(clazz));
+    }
+
+    @Override
+    public <T> List<T> findAll(String tableName, Map<String, Object> filters, Class<T> clazz) {
+        String sql = "SELECT * FROM " + tableName + QueryUtils.whereClause(filters);
+        return jdbcTemplate.query(sql, filters, BeanPropertyRowMapper.newInstance(clazz));
+    }
+
+    @Override
+    public <T> List<T> query(String sql, Map<String, Object> params, Class<T> clazz) {
+        return jdbcTemplate.query(sql, params, BeanPropertyRowMapper.newInstance(clazz));
+    }
+}

--- a/commons/src/main/java/com/split/ai/commons/postgres/QueryUtils.java
+++ b/commons/src/main/java/com/split/ai/commons/postgres/QueryUtils.java
@@ -1,0 +1,24 @@
+package com.split.ai.commons.postgres;
+
+import java.util.Map;
+import java.util.StringJoiner;
+
+/** Utility methods for building SQL queries. */
+final class QueryUtils {
+    private QueryUtils() {}
+
+    static String whereClause(Map<String, Object> filters) {
+        if (filters == null || filters.isEmpty()) {
+            return "";
+        }
+        StringJoiner joiner = new StringJoiner(" AND ", " WHERE ", "");
+        filters.keySet().forEach(key -> joiner.add(key + " = :" + key));
+        return joiner.toString();
+    }
+
+    static String updateAssignments(Map<String, Object> values) {
+        StringJoiner joiner = new StringJoiner(", ");
+        values.keySet().forEach(k -> joiner.add(k + " = :" + k));
+        return joiner.toString();
+    }
+}

--- a/split-service-server/pom.xml
+++ b/split-service-server/pom.xml
@@ -24,6 +24,10 @@
             <groupId>split.ai</groupId>
             <artifactId>split-service-model</artifactId>
         </dependency>
+        <dependency>
+            <groupId>split.ai</groupId>
+            <artifactId>commons</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/split-service-server/src/main/resources/application.yml
+++ b/split-service-server/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/placeholder_db
+    username: user
+    password: password
+    driver-class-name: org.postgresql.Driver
+


### PR DESCRIPTION
## Summary
- implement a `PostgresClient` interface with common CRUD/query operations
- add a JDBC-based implementation and helper utilities
- provide default datasource configuration in `application.yml`
- wire commons module and server module dependencies

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685817d5bffc83229b46fafbfa512a58