### PR TITLE
Refactor entities to store foreign keys

### DIFF
--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/ExpenseEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/ExpenseEntity.java
@@ -7,10 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,15 +28,13 @@ public class ExpenseEntity {
     @Id
     private UUID expenseId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "groupId")
-    private GroupEntity group;
+    @Column(name = "groupId")
+    private UUID groupId;
 
     private String description;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "payerId")
-    private UserEntity payer;
+    @Column(name = "payerId", nullable = false)
+    private UUID payerId;
 
     @Column(nullable = false)
     private BigDecimal amount;
@@ -52,9 +47,8 @@ public class ExpenseEntity {
     @Column(nullable = false)
     private CurrencyType currency;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "categoryId")
-    private CategoryEntity category;
+    @Column(name = "categoryId")
+    private UUID categoryId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/ExpenseShareEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/ExpenseShareEntity.java
@@ -3,10 +3,7 @@ package com.split.ai.split.service.repository.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapsId;
+
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,16 +22,6 @@ public class ExpenseShareEntity {
 
     @EmbeddedId
     private ExpenseShareKey id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("expenseId")
-    @JoinColumn(name = "expenseId")
-    private ExpenseEntity expense;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("userId")
-    @JoinColumn(name = "userId")
-    private UserEntity user;
 
     @Column(nullable = false)
     private BigDecimal sharedAmount;

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/FxRatesEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/FxRatesEntity.java
@@ -3,10 +3,6 @@ package com.split.ai.split.service.repository.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,15 +22,7 @@ public class FxRatesEntity {
     @EmbeddedId
     private FxRatesKey id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("baseCurrency")
-    @JoinColumn(name = "baseCurrency")
-    private CurrencyEntity base;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("quoteCurrency")
-    @JoinColumn(name = "quoteCurrency")
-    private CurrencyEntity quote;
 
     @Column(nullable = false)
     private BigDecimal rate;

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/SettlementEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/SettlementEntity.java
@@ -2,10 +2,7 @@ package com.split.ai.split.service.repository.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,17 +23,14 @@ public class SettlementEntity {
     @Id
     private UUID settlementId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "groupId")
-    private GroupEntity group;
+    @Column(name = "groupId")
+    private UUID groupId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "from_user")
-    private UserEntity fromUser;
+    @Column(name = "from_user", nullable = false)
+    private UUID fromUserId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "to_user")
-    private UserEntity toUser;
+    @Column(name = "to_user", nullable = false)
+    private UUID toUserId;
 
     @Column(nullable = false)
     private BigDecimal amount;

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/UserGroupEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/UserGroupEntity.java
@@ -6,10 +6,6 @@ import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,16 +22,6 @@ public class UserGroupEntity {
 
     @EmbeddedId
     private UserGroupKey id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("groupId")
-    @JoinColumn(name = "groupId")
-    private GroupEntity group;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("userId")
-    @JoinColumn(name = "userId")
-    private UserEntity user;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)


### PR DESCRIPTION
## Summary
- remove lazy `@ManyToOne` associations in repository entities
- map foreign keys directly as UUID columns

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687cfc6856e48322a06cab61e4da0f8f