### PR TITLE
feat(api): add initial controllers and models

### DIFF
--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/ExpenseService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/ExpenseService.java
@@ -1,12 +1,42 @@
 package com.split.ai.split.service.core.service;
 
 import com.split.ai.split.service.core.service.impl.IExpenseService;
+import com.split.ai.split.service.model.request.*;
+import com.split.ai.split.service.model.response.ExpenseHistoryResponse;
+import com.split.ai.split.service.model.response.ExpenseResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+/**
+ * Service handling expense operations.
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class ExpenseService implements IExpenseService {
+    @Override
+    public ExpenseResponse getExpense(String expenseId) {
+        return new ExpenseResponse();
+    }
+
+    @Override
+    public void createExpense(CreateExpenseRequest request) {
+        // no-op
+    }
+
+    @Override
+    public void updateExpense(UpdateExpenseRequest request) {
+        // no-op
+    }
+
+    @Override
+    public void deleteExpense(DeleteExpenseRequest request) {
+        // no-op
+    }
+
+    @Override
+    public ExpenseHistoryResponse getHistory(String expenseId) {
+        return new ExpenseHistoryResponse();
+    }
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/GroupService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/GroupService.java
@@ -1,12 +1,69 @@
 package com.split.ai.split.service.core.service;
 
 import com.split.ai.split.service.core.service.impl.IGroupService;
+import com.split.ai.split.service.model.request.*;
+import com.split.ai.split.service.model.response.GroupExpenseResponse;
+import com.split.ai.split.service.model.response.GroupUserResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
+/**
+ * Service handling group operations.
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class GroupService implements IGroupService {
+    @Override
+    public GroupExpenseResponse getGroupDetails(UUID groupId) {
+        return new GroupExpenseResponse();
+    }
+
+    @Override
+    public void createGroup(CreateGroupRequest request) {
+        // no-op
+    }
+
+    @Override
+    public void addUserToGroup(AddUserToGroupRequest request) {
+        // no-op
+    }
+
+    @Override
+    public void removeUser(UUID groupId, RemoveUserFromGroupRequest request) {
+        // no-op
+    }
+
+    @Override
+    public void toggleSettleMode(ToggleSettleModeRequest request) {
+        // no-op
+    }
+
+    @Override
+    public void leaveGroup(LeaveGroupRequest request) {
+        // no-op
+    }
+
+    @Override
+    public void deleteGroup(DeleteGroupRequest request) {
+        // no-op
+    }
+
+    @Override
+    public void updateGroup(UpdateGroupRequest request) {
+        // no-op
+    }
+
+    @Override
+    public void inviteMember(UUID groupId, InviteMembersToGroupRequest request) {
+        // no-op
+    }
+
+    @Override
+    public GroupUserResponse getMembers(UUID groupId) {
+        return new GroupUserResponse();
+    }
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/SettlementService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/SettlementService.java
@@ -1,0 +1,26 @@
+package com.split.ai.split.service.core.service;
+
+import com.split.ai.split.service.core.service.impl.ISettlementService;
+import com.split.ai.split.service.model.request.SettlementRequest;
+import com.split.ai.split.service.model.response.SettlementResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service handling settlement operations.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SettlementService implements ISettlementService {
+    @Override
+    public void settleUp(SettlementRequest request) {
+        // no-op
+    }
+
+    @Override
+    public SettlementResponse getSettlement(String settlementId) {
+        return new SettlementResponse();
+    }
+}

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/UserService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/UserService.java
@@ -1,12 +1,38 @@
 package com.split.ai.split.service.core.service;
 
 import com.split.ai.split.service.core.service.impl.IUserService;
+import com.split.ai.split.service.model.request.UpdateUserProfileRequest;
+import com.split.ai.split.service.model.response.UserGroupsResponse;
+import com.split.ai.split.service.model.response.UserProfileResponse;
+import com.split.ai.split.service.model.response.UserSuggestResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+/**
+ * Service handling user business logic.
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class UserService implements IUserService {
+    @Override
+    public UserProfileResponse getProfile(String userId) {
+        return new UserProfileResponse();
+    }
+
+    @Override
+    public void updateProfile(String userId, UpdateUserProfileRequest request) {
+        // no-op
+    }
+
+    @Override
+    public UserSuggestResponse suggestUsers(String query, Integer limit) {
+        return new UserSuggestResponse();
+    }
+
+    @Override
+    public UserGroupsResponse getGroups(String userId, Integer page, Integer size) {
+        return new UserGroupsResponse();
+    }
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/IExpenseService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/IExpenseService.java
@@ -1,4 +1,17 @@
 package com.split.ai.split.service.core.service.impl;
 
+import com.split.ai.split.service.model.request.*;
+import com.split.ai.split.service.model.response.ExpenseHistoryResponse;
+import com.split.ai.split.service.model.response.ExpenseResponse;
+
 public interface IExpenseService {
+    ExpenseResponse getExpense(String expenseId);
+
+    void createExpense(CreateExpenseRequest request);
+
+    void updateExpense(UpdateExpenseRequest request);
+
+    void deleteExpense(DeleteExpenseRequest request);
+
+    ExpenseHistoryResponse getHistory(String expenseId);
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/IGroupService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/IGroupService.java
@@ -1,4 +1,29 @@
 package com.split.ai.split.service.core.service.impl;
 
+import com.split.ai.split.service.model.request.*;
+import com.split.ai.split.service.model.response.GroupExpenseResponse;
+import com.split.ai.split.service.model.response.GroupUserResponse;
+
+import java.util.UUID;
+
 public interface IGroupService {
+    GroupExpenseResponse getGroupDetails(UUID groupId);
+
+    void createGroup(CreateGroupRequest request);
+
+    void addUserToGroup(AddUserToGroupRequest request);
+
+    void removeUser(UUID groupId, RemoveUserFromGroupRequest request);
+
+    void toggleSettleMode(ToggleSettleModeRequest request);
+
+    void leaveGroup(LeaveGroupRequest request);
+
+    void deleteGroup(DeleteGroupRequest request);
+
+    void updateGroup(UpdateGroupRequest request);
+
+    void inviteMember(UUID groupId, InviteMembersToGroupRequest request);
+
+    GroupUserResponse getMembers(UUID groupId);
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/ISettlementService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/ISettlementService.java
@@ -1,0 +1,10 @@
+package com.split.ai.split.service.core.service.impl;
+
+import com.split.ai.split.service.model.request.SettlementRequest;
+import com.split.ai.split.service.model.response.SettlementResponse;
+
+public interface ISettlementService {
+    void settleUp(SettlementRequest request);
+
+    SettlementResponse getSettlement(String settlementId);
+}

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/IUserService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/IUserService.java
@@ -1,4 +1,16 @@
 package com.split.ai.split.service.core.service.impl;
 
+import com.split.ai.split.service.model.request.UpdateUserProfileRequest;
+import com.split.ai.split.service.model.response.UserGroupsResponse;
+import com.split.ai.split.service.model.response.UserProfileResponse;
+import com.split.ai.split.service.model.response.UserSuggestResponse;
+
 public interface IUserService {
+    UserProfileResponse getProfile(String userId);
+
+    void updateProfile(String userId, UpdateUserProfileRequest request);
+
+    UserSuggestResponse suggestUsers(String query, Integer limit);
+
+    UserGroupsResponse getGroups(String userId, Integer page, Integer size);
 }

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/AddUserToGroupRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/AddUserToGroupRequest.java
@@ -1,0 +1,33 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Request to add users to a group.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AddUserToGroupRequest implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 5090882816639713474L;
+
+    @NotNull
+    private UUID groupId;
+
+    private List<UserRoleData> additionalUserData;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/CreateExpenseRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/CreateExpenseRequest.java
@@ -1,0 +1,52 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.split.ai.split.service.model.enums.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Request to create an expense.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CreateExpenseRequest implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -7926909423475367034L;
+
+    private UUID groupId;
+
+    private String description;
+
+    @NotNull
+    private BigDecimal amount;
+
+    @NotNull
+    private UUID payerId;
+
+    private SplitMode splitMode;
+
+    private CurrencyType currency;
+
+    private SubCategory subCategory;
+
+    private Category category;
+
+    private List<UserExpenseData> userExpenseDetails;
+
+    private SplitRequest splitRequest;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/CreateGroupRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/CreateGroupRequest.java
@@ -1,0 +1,43 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.split.ai.split.service.model.enums.CurrencyType;
+import com.split.ai.split.service.model.enums.GroupType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Request to create a group.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CreateGroupRequest implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -5430597607738643671L;
+
+    @NotBlank
+    private String groupName;
+
+    @NotNull
+    private UUID userInitiated;
+
+    private List<UserRoleData> additionalUserData;
+
+    private GroupType groupType;
+
+    private CurrencyType baseCurrency;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/DeleteExpenseRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/DeleteExpenseRequest.java
@@ -1,0 +1,33 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * Request to delete an expense.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DeleteExpenseRequest implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -6738109275748764511L;
+
+    @NotNull
+    private UUID expenseId;
+
+    @NotNull
+    private UUID userId;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/DeleteGroupRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/DeleteGroupRequest.java
@@ -1,0 +1,33 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * Request to delete a group.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DeleteGroupRequest implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -6342024445867786754L;
+
+    @NotNull
+    private UUID groupId;
+
+    @NotNull
+    private UUID userId;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/EqualSplitRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/EqualSplitRequest.java
@@ -1,0 +1,28 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Split request for equal splits.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EqualSplitRequest implements SplitRequest {
+    @Serial
+    private static final long serialVersionUID = 2234762523249234567L;
+
+    private List<UUID> users;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/ExactSplitRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/ExactSplitRequest.java
@@ -1,0 +1,27 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.util.List;
+
+/**
+ * Split request for exact amount splits.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ExactSplitRequest implements SplitRequest {
+    @Serial
+    private static final long serialVersionUID = -5402937491442017300L;
+
+    private List<UserAmountSplitDto> userAmountSplitDtoList;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/InviteMembersToGroupRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/InviteMembersToGroupRequest.java
@@ -1,0 +1,28 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * Request to invite a member to group.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class InviteMembersToGroupRequest implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 3095335062768811664L;
+
+    private String emailId;
+    private String phoneNumber;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/LeaveGroupRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/LeaveGroupRequest.java
@@ -1,0 +1,33 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * Request for a member to leave a group.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LeaveGroupRequest implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 6486765462893549643L;
+
+    @NotNull
+    private UUID groupId;
+
+    @NotNull
+    private UUID userId;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/PercentageSplitRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/PercentageSplitRequest.java
@@ -1,4 +1,4 @@
-package main.java.com.split.ai.split.service.model.request;
+package com.split.ai.split.service.model.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -8,18 +8,20 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.io.Serial;
-import java.io.Serializable;
+import java.util.List;
 
+/**
+ * Split request based on percentage.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class UserProfileResponse implements Serializable {
+public class PercentageSplitRequest implements SplitRequest {
     @Serial
-    private static final long serialVersionUID = -1046631501063901127L;
+    private static final long serialVersionUID = -1028392738982734111L;
 
-    private String userId;
-
+    private List<UserPercentageSplitDto> userPercentageSplitDtoList;
 }

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/RatioSplitRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/RatioSplitRequest.java
@@ -1,0 +1,27 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.util.List;
+
+/**
+ * Split request based on ratios.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RatioSplitRequest implements SplitRequest {
+    @Serial
+    private static final long serialVersionUID = -171283492872883491L;
+
+    private List<UserRatioSplitDto> userRatioSplitDtoList;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/RemoveUserFromGroupRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/RemoveUserFromGroupRequest.java
@@ -1,0 +1,33 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * Request to remove a user from a group.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RemoveUserFromGroupRequest implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 8848459342264066162L;
+
+    @NotNull
+    private UUID userInitiated;
+
+    @NotNull
+    private UUID userToRemove;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/SettlementRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/SettlementRequest.java
@@ -1,0 +1,42 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.split.ai.split.service.model.enums.CurrencyType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Request to settle up between users.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SettlementRequest implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -6715643255431458720L;
+
+    private UUID groupId;
+
+    @NotNull
+    private UUID payerId;
+
+    @NotNull
+    private UUID receiverId;
+
+    @NotNull
+    private BigDecimal amount;
+
+    private CurrencyType currency;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/SplitRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/SplitRequest.java
@@ -1,0 +1,9 @@
+package com.split.ai.split.service.model.request;
+
+import java.io.Serializable;
+
+/**
+ * Base marker interface for split requests.
+ */
+public interface SplitRequest extends Serializable {
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/ToggleSettleModeRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/ToggleSettleModeRequest.java
@@ -1,0 +1,33 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.split.ai.split.service.model.enums.SettleMode;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * Request to toggle a group's settle mode.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ToggleSettleModeRequest implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -4874568392430909921L;
+
+    @NotNull
+    private UUID groupId;
+
+    private SettleMode settleMode;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/UpdateExpenseRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/UpdateExpenseRequest.java
@@ -1,0 +1,48 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.split.ai.split.service.model.enums.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Request to update an expense.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UpdateExpenseRequest implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -8353749821743269398L;
+
+    @NotNull
+    private UUID expenseId;
+
+    @NotNull
+    private UUID editedBy;
+
+    private UUID payer;
+    private BigDecimal amount;
+    private Long expenseDate;
+    private SplitMode splitMode;
+    private CurrencyType currency;
+    private Category category;
+    private SubCategory subCategory;
+    private String description;
+    private String metaData;
+    private List<UserExpenseData> userExpenseDetails;
+    private SplitRequest splitRequest;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/UpdateGroupRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/UpdateGroupRequest.java
@@ -1,0 +1,35 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.split.ai.split.service.model.enums.GroupType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * Request to update a group's details.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UpdateGroupRequest implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 5713921175270602855L;
+
+    @NotNull
+    private UUID groupId;
+
+    private String newGroupName;
+
+    private GroupType newGrouptType;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/UpdateUserProfileRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/UpdateUserProfileRequest.java
@@ -1,0 +1,45 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.split.ai.split.service.model.enums.LANGUAGE;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * Request to update user profile.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UpdateUserProfileRequest implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -8475630961048441032L;
+
+    @NotNull
+    private UUID userId;
+
+    @NotBlank
+    private String firstName;
+
+    @NotBlank
+    private String lastName;
+
+    @NotBlank
+    private String emailId;
+
+    private String phoneNumber;
+
+    private LANGUAGE language;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/UserAmountSplitDto.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/UserAmountSplitDto.java
@@ -1,0 +1,34 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * DTO for user amount splits.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserAmountSplitDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -9205911247798388742L;
+
+    @NotNull
+    private UUID userId;
+
+    @NotNull
+    private BigDecimal amount;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/UserPercentageSplitDto.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/UserPercentageSplitDto.java
@@ -1,0 +1,34 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * DTO for user percentage splits.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserPercentageSplitDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 919730907992771693L;
+
+    @NotNull
+    private UUID userId;
+
+    @NotNull
+    private BigDecimal percentage;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/UserRatioSplitDto.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/UserRatioSplitDto.java
@@ -1,0 +1,33 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * DTO for user ratio splits.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserRatioSplitDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -8267087658399034798L;
+
+    @NotNull
+    private UUID userId;
+
+    @NotNull
+    private Integer ratio;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/UserRoleData.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/UserRoleData.java
@@ -1,0 +1,32 @@
+package com.split.ai.split.service.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.split.ai.split.service.model.enums.Role;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * User role information for group operations.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserRoleData implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 2087726348710016234L;
+
+    @NotNull
+    private UUID userId;
+    private Role role;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/ExpenseEditDto.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/ExpenseEditDto.java
@@ -1,0 +1,51 @@
+package com.split.ai.split.service.model.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.split.ai.split.service.model.enums.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * DTO capturing one edit history entry of an expense.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ExpenseEditDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -7338268945012745668L;
+
+    private UUID editedBy;
+    private UUID payerOld;
+    private UUID payerNew;
+    private BigDecimal amountOld;
+    private BigDecimal amountNew;
+    private Long expenseDateOld;
+    private Long expenseDateNew;
+    private SplitMode splitModeOld;
+    private SplitMode splitModeNew;
+    private CurrencyType currencyOld;
+    private CurrencyType currencyNew;
+    private Category categoryOld;
+    private Category categoryNew;
+    private SubCategory subCategoryOld;
+    private SubCategory subCategoryNew;
+    private String descriptionOld;
+    private String descriptionNew;
+    private String metaDataOld;
+    private String metaDataNew;
+    private Map<UUID, BigDecimal> userSharesOld;
+    private Map<UUID, BigDecimal> userSharesNew;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/ExpenseHistoryResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/ExpenseHistoryResponse.java
@@ -1,0 +1,28 @@
+package com.split.ai.split.service.model.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Response containing history of edits of an expense.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ExpenseHistoryResponse implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 8638764548492345875L;
+
+    private List<ExpenseEditDto> expenseEditList;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/ExpenseResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/ExpenseResponse.java
@@ -1,0 +1,42 @@
+package com.split.ai.split.service.model.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.split.ai.split.service.model.enums.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Response containing expense details.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ExpenseResponse implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 3317623450938642376L;
+
+    private UUID expenseId;
+    private UUID groupId;
+    private UUID payerId;
+    private BigDecimal amount;
+    private String description;
+    private SplitMode splitMode;
+    private CurrencyType currency;
+    private Category category;
+    private SubCategory subCategory;
+    private ExpenseStatus expenseStatus;
+    private Long createdAt;
+    private List<UserExpenseData> userExpenseDetails;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/GroupExpenseResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/GroupExpenseResponse.java
@@ -1,0 +1,29 @@
+package com.split.ai.split.service.model.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Detailed group response along with active expenses.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GroupExpenseResponse implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1598743627045806325L;
+
+    private UserGroupResponse userGroup;
+    private List<ExpenseResponse> expenses;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/GroupUserResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/GroupUserResponse.java
@@ -1,0 +1,31 @@
+package com.split.ai.split.service.model.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.split.ai.split.service.model.request.UserRoleData;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Response listing members of a group.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GroupUserResponse implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -1858091527375318232L;
+
+    private UUID groupId;
+    private List<UserRoleData> groupUserData;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/SettlementResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/SettlementResponse.java
@@ -1,0 +1,37 @@
+package com.split.ai.split.service.model.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.split.ai.split.service.model.enums.CurrencyType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Response representing a settlement entry.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SettlementResponse implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 2324768235789345345L;
+
+    private UUID settlementId;
+    private UUID groupId;
+    private UUID fromUser;
+    private UUID toUser;
+    private BigDecimal amount;
+    private CurrencyType currencyType;
+    private String note;
+    private Long createdAt;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/UserExpenseData.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/UserExpenseData.java
@@ -1,0 +1,31 @@
+package com.split.ai.split.service.model.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Expense share for a user.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserExpenseData implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -7268079979190168183L;
+
+    private UUID expenseId;
+    private UUID userId;
+    private BigDecimal sharedAmount;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/UserGroupResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/UserGroupResponse.java
@@ -1,0 +1,33 @@
+package com.split.ai.split.service.model.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.split.ai.split.service.model.enums.GroupType;
+import com.split.ai.split.service.model.enums.SettleMode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * Response describing a group the user is part of.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserGroupResponse implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -5096029048812009946L;
+
+    private UUID groupId;
+    private String groupName;
+    private GroupType groupType;
+    private SettleMode settleMode;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/UserGroupsResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/UserGroupsResponse.java
@@ -1,0 +1,28 @@
+package com.split.ai.split.service.model.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Response containing the groups for a user.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserGroupsResponse implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -8447416838840534884L;
+
+    private List<UserGroupResponse> userGroups;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/UserProfileResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/UserProfileResponse.java
@@ -1,0 +1,35 @@
+package com.split.ai.split.service.model.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.split.ai.split.service.model.enums.LANGUAGE;
+import com.split.ai.split.service.model.enums.UserStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * Response containing user profile details.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserProfileResponse implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -1046631501063901127L;
+
+    private String userId;
+    private String emailId;
+    private String firstName;
+    private String lastName;
+    private String userName;
+    private UserStatus userStatus;
+    private LANGUAGE language;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/UserSuggestData.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/UserSuggestData.java
@@ -1,0 +1,32 @@
+package com.split.ai.split.service.model.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * Data describing a suggested user.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserSuggestData implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -6204019922328291179L;
+
+    private UUID userId;
+    private String userName;
+    private String name;
+    private String emailId;
+    private String phone;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/UserSuggestResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/UserSuggestResponse.java
@@ -1,0 +1,28 @@
+package com.split.ai.split.service.model.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Response for user suggestions when adding members.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserSuggestResponse implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 237945437923740834L;
+
+    private List<UserSuggestData> userSuggestDatas;
+}

--- a/split-service-server/src/main/java/com/split/ai/split/service/server/controller/ExpenseController.java
+++ b/split-service-server/src/main/java/com/split/ai/split/service/server/controller/ExpenseController.java
@@ -1,11 +1,57 @@
 package com.split.ai.split.service.server.controller;
 
+import com.split.ai.split.service.core.service.ExpenseService;
+import com.split.ai.split.service.model.request.*;
+import com.split.ai.split.service.model.response.ExpenseHistoryResponse;
+import com.split.ai.split.service.model.response.ExpenseResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+/**
+ * Controller for expense related operations.
+ */
 @RestController
 @RequestMapping("/v1/expenses")
 @RequiredArgsConstructor
+@Slf4j
 public class ExpenseController {
+
+    private final ExpenseService expenseService;
+
+    @GetMapping("/get/{expenseId}")
+    public ResponseEntity<ExpenseResponse> getExpense(@PathVariable @NotBlank String expenseId) {
+        log.info("[ExpenseController : getExpense] : {}", expenseId);
+        return ResponseEntity.ok(expenseService.getExpense(expenseId));
+    }
+
+    @PostMapping("/create")
+    public ResponseEntity<Void> createExpense(@Valid @RequestBody CreateExpenseRequest request) {
+        log.info("[ExpenseController : createExpense] : {}", request);
+        expenseService.createExpense(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/update")
+    public ResponseEntity<Void> updateExpense(@Valid @RequestBody UpdateExpenseRequest request) {
+        log.info("[ExpenseController : updateExpense] : {}", request);
+        expenseService.updateExpense(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<Void> deleteExpense(@Valid @RequestBody DeleteExpenseRequest request) {
+        log.info("[ExpenseController : deleteExpense] : {}", request);
+        expenseService.deleteExpense(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{expenseId}/history")
+    public ResponseEntity<ExpenseHistoryResponse> getExpenseHistory(@PathVariable @NotBlank String expenseId) {
+        log.info("[ExpenseController : getExpenseHistory] : {}", expenseId);
+        return ResponseEntity.ok(expenseService.getHistory(expenseId));
+    }
 }

--- a/split-service-server/src/main/java/com/split/ai/split/service/server/controller/GroupController.java
+++ b/split-service-server/src/main/java/com/split/ai/split/service/server/controller/GroupController.java
@@ -1,11 +1,98 @@
 package com.split.ai.split.service.server.controller;
 
+import com.split.ai.split.service.core.service.GroupService;
+import com.split.ai.split.service.model.request.*;
+import com.split.ai.split.service.model.response.GroupExpenseResponse;
+import com.split.ai.split.service.model.response.GroupUserResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
+/**
+ * Controller for group operations.
+ */
 @RestController
 @RequestMapping("/v1/groups")
 @RequiredArgsConstructor
+@Slf4j
 public class GroupController {
+
+    private final GroupService groupService;
+
+    @GetMapping("/{groupId}/detailed")
+    public ResponseEntity<GroupExpenseResponse> getGroupDetails(@PathVariable @NotBlank String groupId) {
+        log.info("[GroupController : getGroupDetails] : {}", groupId);
+        return ResponseEntity.ok(groupService.getGroupDetails(UUID.fromString(groupId)));
+    }
+
+    @PostMapping("/create")
+    public ResponseEntity<Void> createGroup(@Valid @RequestBody CreateGroupRequest request) {
+        log.info("[GroupController : createGroup] : {}", request);
+        groupService.createGroup(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/add-user")
+    public ResponseEntity<Void> addUser(@Valid @RequestBody AddUserToGroupRequest request) {
+        log.info("[GroupController : addUser] : {}", request);
+        groupService.addUserToGroup(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/{groupId}/remove-user")
+    public ResponseEntity<Void> removeUser(@PathVariable @NotBlank String groupId,
+                                           @Valid @RequestBody RemoveUserFromGroupRequest request) {
+        log.info("[GroupController : removeUser] : {}", request);
+        groupService.removeUser(UUID.fromString(groupId), request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/toggle-mode")
+    public ResponseEntity<Void> toggleMode(@Valid @RequestBody ToggleSettleModeRequest request) {
+        log.info("[GroupController : toggleMode] : {}", request);
+        groupService.toggleSettleMode(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/leave")
+    public ResponseEntity<Void> leaveGroup(@Valid @RequestBody LeaveGroupRequest request) {
+        log.info("[GroupController : leaveGroup] : {}", request);
+        groupService.leaveGroup(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<Void> deleteGroup(@Valid @RequestBody DeleteGroupRequest request) {
+        log.info("[GroupController : deleteGroup] : {}", request);
+        groupService.deleteGroup(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/update/{groupId}")
+    public ResponseEntity<Void> updateGroup(@PathVariable @NotBlank String groupId,
+                                            @Valid @RequestBody UpdateGroupRequest request) {
+        log.info("[GroupController : updateGroup] : {}", request);
+        request.setGroupId(UUID.fromString(groupId));
+        groupService.updateGroup(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{groupId}/members/invite")
+    public ResponseEntity<Void> inviteMember(@PathVariable @NotBlank String groupId,
+                                             @Valid @RequestBody InviteMembersToGroupRequest request) {
+        log.info("[GroupController : inviteMember] : {}", request);
+        groupService.inviteMember(UUID.fromString(groupId), request);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/members/{groupId}")
+    public ResponseEntity<GroupUserResponse> getMembers(@PathVariable @NotBlank String groupId) {
+        log.info("[GroupController : getMembers] : {}", groupId);
+        return ResponseEntity.ok(groupService.getMembers(UUID.fromString(groupId)));
+    }
 }

--- a/split-service-server/src/main/java/com/split/ai/split/service/server/controller/SettlementController.java
+++ b/split-service-server/src/main/java/com/split/ai/split/service/server/controller/SettlementController.java
@@ -1,11 +1,36 @@
 package com.split.ai.split.service.server.controller;
 
+import com.split.ai.split.service.core.service.SettlementService;
+import com.split.ai.split.service.model.request.SettlementRequest;
+import com.split.ai.split.service.model.response.SettlementResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+/**
+ * Controller for handling settlements.
+ */
 @RestController
 @RequestMapping("/v1/settlements")
 @RequiredArgsConstructor
+@Slf4j
 public class SettlementController {
+
+    private final SettlementService settlementService;
+
+    @PostMapping
+    public ResponseEntity<Void> settleUp(@Valid @RequestBody SettlementRequest request) {
+        log.info("[SettlementController : settleUp] : {}", request);
+        settlementService.settleUp(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{settlementId}")
+    public ResponseEntity<SettlementResponse> getSettlement(@PathVariable @NotBlank String settlementId) {
+        log.info("[SettlementController : getSettlement] : {}", settlementId);
+        return ResponseEntity.ok(settlementService.getSettlement(settlementId));
+    }
 }

--- a/split-service-server/src/main/java/com/split/ai/split/service/server/controller/UserController.java
+++ b/split-service-server/src/main/java/com/split/ai/split/service/server/controller/UserController.java
@@ -1,12 +1,54 @@
 package com.split.ai.split.service.server.controller;
 
+import com.split.ai.split.service.core.service.UserService;
+import com.split.ai.split.service.model.request.UpdateUserProfileRequest;
+import com.split.ai.split.service.model.response.UserGroupsResponse;
+import com.split.ai.split.service.model.response.UserProfileResponse;
+import com.split.ai.split.service.model.response.UserSuggestResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+/**
+ * Controller handling user related operations.
+ */
 @RestController
 @RequestMapping("/v1/users")
 @RequiredArgsConstructor
+@Slf4j
 public class UserController {
 
+    private final UserService userService;
+
+    @GetMapping("/profile/{userId}")
+    public ResponseEntity<UserProfileResponse> getProfile(@PathVariable @NotBlank String userId) {
+        log.info("[UserController : getProfile] : fetching profile for {}", userId);
+        return ResponseEntity.ok(userService.getProfile(userId));
+    }
+
+    @PatchMapping("/update/{userId}")
+    public ResponseEntity<Void> updateProfile(@PathVariable @NotBlank String userId,
+                                              @Valid @RequestBody UpdateUserProfileRequest request) {
+        log.info("[UserController : updateProfile] : updating profile {}", request);
+        userService.updateProfile(userId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/suggest")
+    public ResponseEntity<UserSuggestResponse> suggestUsers(@RequestParam("query") String query,
+                                                            @RequestParam(value = "limit", required = false) Integer limit) {
+        log.info("[UserController : suggestUsers] : query {}", query);
+        return ResponseEntity.ok(userService.suggestUsers(query, limit));
+    }
+
+    @GetMapping("/{userId}/groups")
+    public ResponseEntity<UserGroupsResponse> getUserGroups(@PathVariable @NotBlank String userId,
+                                                            @RequestParam(value = "page", required = false) Integer page,
+                                                            @RequestParam(value = "size", required = false) Integer size) {
+        log.info("[UserController : getUserGroups] : groups for {}", userId);
+        return ResponseEntity.ok(userService.getGroups(userId, page, size));
+    }
 }


### PR DESCRIPTION
## Summary
- implement skeleton controllers for users, groups, expenses and settlements
- add placeholder requests and responses in model module
- create basic service interfaces and stubs

## Testing
- `mvn -q -DskipTests compile` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68866a9de0f88322b863937a60703777