### PR TITLE
feat(user): add pg_trgm based user suggestion

### DIFF
--- a/commons/src/main/java/com/split/ai/commons/postgres/PostgresClient.java
+++ b/commons/src/main/java/com/split/ai/commons/postgres/PostgresClient.java
@@ -41,4 +41,7 @@ public interface PostgresClient {
     <T> List<T> query(String jpql, Map<String, Object> params, Class<T> cls, LockModeType lockMode);
 
     <T> List<T> query(String jpql, Map<String, Object> params, Class<T> cls, LockModeType lockMode, int lockTimeout);
+
+    <T> List<T> queryNative(String sql, Map<String, Object> params, Class<T> cls);
+
 }

--- a/commons/src/main/java/com/split/ai/commons/postgres/PostgresClientImpl.java
+++ b/commons/src/main/java/com/split/ai/commons/postgres/PostgresClientImpl.java
@@ -131,6 +131,15 @@ public class PostgresClientImpl implements PostgresClient {
         return query.getResultList();
     }
 
+    @Override
+    public <T> List<T> queryNative(String sql, Map<String, Object> params, Class<T> cls) {
+        jakarta.persistence.Query query = entityManager.createNativeQuery(sql, cls);
+        if (params != null) {
+            params.forEach(query::setParameter);
+        }
+        return query.getResultList();
+    }
+
     private <T> T doPartialUpdate(T object, LockModeType lockMode, Integer lockTimeout) {
         Class<T> cls = (Class<T>) object.getClass();
         Object id = entityManager.getEntityManagerFactory().getPersistenceUnitUtil().getIdentifier(object);

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/UserServiceMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/UserServiceMapper.java
@@ -1,7 +1,11 @@
 package com.split.ai.split.service.core.mapper;
 
 import com.split.ai.split.service.model.response.user.UserProfileResponse;
+import com.split.ai.split.service.model.response.user.UserGroupResponse;
+import com.split.ai.split.service.model.response.user.UserSuggestDto;
 import com.split.ai.split.service.repository.entity.UserEntity;
+import com.split.ai.split.service.model.request.user.UpdateUserProfileRequest;
+import com.split.ai.split.service.repository.entity.GroupEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
@@ -11,4 +15,10 @@ public interface UserServiceMapper extends BaseServiceMapper {
     UserServiceMapper MAPPER = Mappers.getMapper(UserServiceMapper.class);
 
     UserProfileResponse convert(UserEntity entity);
+
+    UserSuggestDto convertToSuggest(UserEntity entity);
+
+    UserEntity convert(UpdateUserProfileRequest request);
+
+    UserGroupResponse convert(GroupEntity entity);
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/UserService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/UserService.java
@@ -37,19 +37,31 @@ public class UserService implements IUserService {
 
     @Override
     public void updateProfile(UUID userId, UpdateUserProfileRequest request) {
-        UserEntity user =
-        userDao.update();
+        log.info("[UserService : updateProfile] : updating {}", userId);
+        UserEntity entity = UserServiceMapper.MAPPER.convert(request);
+        entity.setUserId(userId);
+        entity.setUpdatedAt(System.currentTimeMillis());
+        userDao.update(entity);
     }
 
     @Override
     public UserSuggestResponse suggestUsers(String query, Integer limit) {
         ValidationUtil.validateSuggestUserQuery(query);
-        return new UserSuggestResponse();
+        List<UserEntity> users = userDao.suggestUsers(query, limit);
+        return UserSuggestResponse.builder()
+                .userSuggestDtos(users.stream()
+                        .map(UserServiceMapper.MAPPER::convertToSuggest)
+                        .toList())
+                .build();
     }
 
     @Override
     public UserGroupsResponse getGroups(UUID userId, Integer page, Integer size) {
         List<GroupEntity> groups = groupDao.findByUserIdPaginated(userId, page, size);
-        return new UserGroupsResponse();
+        return UserGroupsResponse.builder()
+                .userGroups(groups.stream()
+                        .map(UserServiceMapper.MAPPER::convert)
+                        .toList())
+                .build();
     }
 }

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/IUserDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/IUserDao.java
@@ -2,6 +2,7 @@ package com.split.ai.split.service.repository.dao;
 
 import com.split.ai.split.service.repository.entity.UserEntity;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface IUserDao {
@@ -11,5 +12,7 @@ public interface IUserDao {
     void update(UserEntity entity);
 
     UserEntity findById(UUID userId);
+
+    List<UserEntity> suggestUsers(String query, Integer limit);
 
 }

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/GroupDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/GroupDao.java
@@ -1,4 +1,58 @@
 package com.split.ai.split.service.repository.dao.impl;
 
-public class GroupDao {
+import com.split.ai.commons.postgres.PostgresClient;
+import com.split.ai.split.service.repository.dao.IGroupDao;
+import com.split.ai.split.service.repository.entity.GroupEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Data access object for {@link GroupEntity}.
+ */
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class GroupDao implements IGroupDao {
+
+    private final PostgresClient postgresClient;
+
+    @Override
+    public void save(GroupEntity entity) {
+        log.debug("[GroupDao : save] : {}", entity);
+        postgresClient.insert(entity);
+    }
+
+    @Override
+    public void update(GroupEntity entity) {
+        log.debug("[GroupDao : update] : {}", entity);
+        postgresClient.partialUpdate(entity);
+    }
+
+    @Override
+    public GroupEntity findById(UUID groupId) {
+        log.debug("[GroupDao : findById] : {}", groupId);
+        return postgresClient.findById(GroupEntity.class, groupId);
+    }
+
+    @Override
+    public List<GroupEntity> findByUserIdPaginated(UUID userId, Integer page, Integer size) {
+        log.debug("[GroupDao : findByUserIdPaginated] : user {} page {} size {}", userId, page, size);
+        String sql = "SELECT g.* FROM groups g " +
+                "JOIN user_group ug ON g.group_id = ug.group_id " +
+                "WHERE ug.user_id = :userId " +
+                "ORDER BY g.created_at DESC " +
+                "LIMIT :limit OFFSET :offset";
+        Map<String, Object> params = new HashMap<>();
+        params.put("userId", userId);
+        params.put("limit", size);
+        params.put("offset", (page - 1L) * size);
+        return postgresClient.queryNative(sql, params, GroupEntity.class);
+    }
 }
+

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/UserDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/UserDao.java
@@ -1,4 +1,63 @@
 package com.split.ai.split.service.repository.dao.impl;
 
-public class UserDao {
+import com.split.ai.commons.postgres.PostgresClient;
+import com.split.ai.split.service.repository.dao.IUserDao;
+import com.split.ai.split.service.repository.entity.UserEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Data access object for {@link UserEntity}.
+ */
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class UserDao implements IUserDao {
+
+    private final PostgresClient postgresClient;
+
+    @Override
+    public void save(UserEntity entity) {
+        log.debug("[UserDao : save] : {}", entity);
+        postgresClient.insert(entity);
+    }
+
+    @Override
+    public void update(UserEntity entity) {
+        log.debug("[UserDao : update] : {}", entity);
+        postgresClient.partialUpdate(entity);
+    }
+
+    @Override
+    public UserEntity findById(UUID userId) {
+        log.debug("[UserDao : findById] : {}", userId);
+        return postgresClient.findById(UserEntity.class, userId);
+    }
+
+    @Override
+    public List<UserEntity> suggestUsers(String query, Integer limit) {
+        log.debug("[UserDao : suggestUsers] : query {} limit {}", query, limit);
+        String sql = "SELECT * FROM users " +
+                "WHERE user_name % :query " +
+                "   OR full_name % :query " +
+                "   OR phone % :query " +
+                "   OR email_id % :query " +
+                "ORDER BY GREATEST(" +
+                "   SIMILARITY(user_name, :query)," +
+                "   SIMILARITY(full_name, :query)," +
+                "   SIMILARITY(phone, :query)," +
+                "   SIMILARITY(email_id, :query)" +
+                ") DESC LIMIT :limit";
+        Map<String, Object> params = new HashMap<>();
+        params.put("query", query);
+        params.put("limit", limit);
+        return postgresClient.queryNative(sql, params, UserEntity.class);
+    }
 }
+

--- a/split-service-server/src/main/resources/db/migration/V1__user_trgm_indexes.sql
+++ b/split-service-server/src/main/resources/db/migration/V1__user_trgm_indexes.sql
@@ -1,0 +1,6 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_users_user_name_trgm ON users USING gin (user_name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_users_full_name_trgm ON users USING gin (full_name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_users_phone_trgm ON users USING gin (phone gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_users_email_id_trgm ON users USING gin (email_id gin_trgm_ops);


### PR DESCRIPTION
## Summary
- add native query support in PostgresClient
- implement user and group DAOs with pg_trgm suggestions
- wire UserService to provide ranked user suggestions and group listing
- add SQL migration for trigram indexes

## Testing
- `mvn -q -pl split-service-server -am test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f514bdb6c8322a27c73bb5a50b452