### PR TITLE
feat: add beforeInsertOrUpdate hooks for entities and DAOs

### DIFF
--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/GroupDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/GroupDao.java
@@ -25,12 +25,14 @@ public class GroupDao implements IGroupDao {
     @Override
     public void save(GroupEntity entity) {
         log.debug("[GroupDao : save] : {}", entity);
+        entity.beforeInsertOrUpdate();
         postgresClient.insert(entity);
     }
 
     @Override
     public void update(GroupEntity entity) {
         log.debug("[GroupDao : update] : {}", entity);
+        entity.beforeInsertOrUpdate();
         postgresClient.partialUpdate(entity);
     }
 

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/UserDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/UserDao.java
@@ -25,12 +25,14 @@ public class UserDao implements IUserDao {
     @Override
     public void save(UserEntity entity) {
         log.debug("[UserDao : save] : {}", entity);
+        entity.beforeInsertOrUpdate();
         postgresClient.insert(entity);
     }
 
     @Override
     public void update(UserEntity entity) {
         log.debug("[UserDao : update] : {}", entity);
+        entity.beforeInsertOrUpdate();
         postgresClient.partialUpdate(entity);
     }
 

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/CategoryEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/CategoryEntity.java
@@ -31,4 +31,8 @@ public class CategoryEntity {
     private Category category;
 
     private String subCategoryImageUrl;
+
+    public void beforeInsertOrUpdate() {
+        // No-op for now
+    }
 }

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/CurrencyEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/CurrencyEntity.java
@@ -30,4 +30,8 @@ public class CurrencyEntity {
     private CurrencyType currency;
 
     private String currencySymbolUrl;
+
+    public void beforeInsertOrUpdate() {
+        // No-op for now
+    }
 }

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/ExpenseEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/ExpenseEntity.java
@@ -45,4 +45,12 @@ public class ExpenseEntity {
     @UpdateTimestamp
     @Column(nullable = false)
     private Long updatedAt;
+
+    public void beforeInsertOrUpdate() {
+        long now = System.currentTimeMillis();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        updatedAt = now;
+    }
 }

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/ExpenseRevisionEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/ExpenseRevisionEntity.java
@@ -100,4 +100,10 @@ public class ExpenseRevisionEntity {
     @Type(JsonType.class)
     @Column(columnDefinition = "jsonb", nullable = false)
     private Map<UUID, BigDecimal> userShares;
+
+    public void beforeInsertOrUpdate() {
+        if (editedAt == null) {
+            editedAt = System.currentTimeMillis();
+        }
+    }
 }

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/GroupEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/GroupEntity.java
@@ -52,4 +52,12 @@ public class GroupEntity {
 
     @Column(nullable = false)
     private Long updatedAt;
+
+    public void beforeInsertOrUpdate() {
+        long now = System.currentTimeMillis();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        updatedAt = now;
+    }
 }

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/SettlementEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/SettlementEntity.java
@@ -55,4 +55,10 @@ public class SettlementEntity {
 
     @Column(nullable = false, updatable = false)
     private Long createdAt;
+
+    public void beforeInsertOrUpdate() {
+        if (createdAt == null) {
+            createdAt = System.currentTimeMillis();
+        }
+    }
 }

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/UserEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/UserEntity.java
@@ -54,4 +54,12 @@ public class UserEntity {
 
     @Column(nullable = false)
     private Long updatedAt;
+
+    public void beforeInsertOrUpdate() {
+        long now = System.currentTimeMillis();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        updatedAt = now;
+    }
 }

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/UserGroupEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/UserGroupEntity.java
@@ -28,4 +28,10 @@ public class UserGroupEntity {
     private Role role;
 
     private Long createdAt;
+
+    public void beforeInsertOrUpdate() {
+        if (createdAt == null) {
+            createdAt = System.currentTimeMillis();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add `beforeInsertOrUpdate` hook to entity classes
- invoke entity hook in existing DAO implementations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_688f598abe88832287275b7b27ea2073