### PR TITLE
refactor(service): delegate object creation to mappers

### DIFF
--- a/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/BaseServiceMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/BaseServiceMapper.java
@@ -1,4 +1,13 @@
 package com.split.ai.split.service.core.mapper;
 
+import org.mapstruct.Named;
+
+import java.util.UUID;
+
 public interface BaseServiceMapper {
+
+    @Named("randomUUID")
+    default UUID randomUUID() {
+        return UUID.randomUUID();
+    }
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/GroupServiceMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/GroupServiceMapper.java
@@ -1,10 +1,73 @@
 package com.split.ai.split.service.core.mapper;
 
+import com.split.ai.split.service.model.enums.GroupStatus;
+import com.split.ai.split.service.model.enums.GroupType;
+import com.split.ai.split.service.model.enums.Role;
+import com.split.ai.split.service.model.enums.SettleMode;
+import com.split.ai.split.service.model.request.group.CreateGroupRequest;
+import com.split.ai.split.service.model.request.group.DeleteGroupRequest;
+import com.split.ai.split.service.model.request.group.ToggleGroupSettleMode;
+import com.split.ai.split.service.model.request.group.UpdateGroupRequest;
+import com.split.ai.split.service.model.request.user.UserRoleData;
+import com.split.ai.split.service.model.response.expense.ExpenseResponse;
+import com.split.ai.split.service.model.response.group.GroupExpenseResponse;
+import com.split.ai.split.service.model.response.group.GroupUserResponse;
+import com.split.ai.split.service.model.response.user.UserGroupResponse;
+import com.split.ai.split.service.repository.entity.ExpenseEntity;
+import com.split.ai.split.service.repository.entity.GroupEntity;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
-@Mapper
+import java.util.List;
+import java.util.UUID;
+
+@Mapper(imports = {SettleMode.class, GroupStatus.class, Role.class, GroupType.class})
 public interface GroupServiceMapper extends BaseServiceMapper {
 
     GroupServiceMapper MAPPER = Mappers.getMapper(GroupServiceMapper.class);
+
+    @Mapping(target = "groupId", qualifiedByName = "randomUUID")
+    @Mapping(target = "groupType", source = "groupType", qualifiedByName = "defaultGroupType")
+    @Mapping(target = "currency", source = "baseCurrency")
+    @Mapping(target = "settleMode", expression = "java(SettleMode.NORMAL_SETTLE)")
+    @Mapping(target = "groupStatus", expression = "java(GroupStatus.ACTIVE)")
+    GroupEntity convert(CreateGroupRequest request);
+
+    @Mapping(target = "groupId", source = "groupId")
+    @Mapping(target = "settleMode", source = "settleMode")
+    GroupEntity convert(ToggleGroupSettleMode request);
+
+    @Mapping(target = "groupId", source = "groupId")
+    @Mapping(target = "groupStatus", expression = "java(GroupStatus.DELETED)")
+    GroupEntity convert(DeleteGroupRequest request);
+
+    @Mapping(target = "groupId", source = "groupId")
+    @Mapping(target = "groupName", source = "newGroupName")
+    @Mapping(target = "groupType", source = "newGrouptType")
+    GroupEntity convert(UpdateGroupRequest request);
+
+    @Mapping(target = "userGroup", source = "group")
+    @Mapping(target = "expenses", source = "expenses")
+    GroupExpenseResponse convert(GroupEntity group, List<ExpenseEntity> expenses);
+
+    UserGroupResponse convert(GroupEntity entity);
+
+    @Mapping(target = "expenseId", source = "expenseId")
+    @Mapping(target = "groupId", source = "group.groupId")
+    ExpenseResponse convert(ExpenseEntity entity);
+
+    @Mapping(target = "groupId", source = "groupId")
+    @Mapping(target = "groupUserData", source = "groupUserData")
+    GroupUserResponse convert(UUID groupId, List<UserRoleData> groupUserData);
+
+    @Mapping(target = "userId", source = "userId")
+    @Mapping(target = "role", expression = "java(Role.ADMIN)")
+    UserRoleData createAdmin(UUID userId);
+
+    @Named("defaultGroupType")
+    default GroupType defaultGroupType(GroupType groupType) {
+        return groupType == null ? GroupType.COMMON : groupType;
+    }
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/UserServiceMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/UserServiceMapper.java
@@ -3,11 +3,16 @@ package com.split.ai.split.service.core.mapper;
 import com.split.ai.split.service.model.response.user.UserProfileResponse;
 import com.split.ai.split.service.model.response.user.UserGroupResponse;
 import com.split.ai.split.service.model.response.user.UserSuggestDto;
+import com.split.ai.split.service.model.response.user.UserSuggestResponse;
+import com.split.ai.split.service.model.response.user.UserGroupsResponse;
 import com.split.ai.split.service.repository.entity.UserEntity;
 import com.split.ai.split.service.model.request.user.UpdateUserProfileRequest;
 import com.split.ai.split.service.repository.entity.GroupEntity;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
+
+import java.util.List;
 
 @Mapper
 public interface UserServiceMapper extends BaseServiceMapper {
@@ -21,4 +26,10 @@ public interface UserServiceMapper extends BaseServiceMapper {
     UserEntity convert(UpdateUserProfileRequest request);
 
     UserGroupResponse convert(GroupEntity entity);
+
+    @Mapping(target = "userSuggestDtos", source = "users")
+    UserSuggestResponse convertToSuggestResponse(List<UserEntity> users);
+
+    @Mapping(target = "userGroups", source = "groups")
+    UserGroupsResponse convertToGroupsResponse(List<GroupEntity> groups);
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/GroupService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/GroupService.java
@@ -1,10 +1,7 @@
 package com.split.ai.split.service.core.service.impl;
 
+import com.split.ai.split.service.core.mapper.GroupServiceMapper;
 import com.split.ai.split.service.core.service.IGroupService;
-import com.split.ai.split.service.model.enums.GroupStatus;
-import com.split.ai.split.service.model.enums.GroupType;
-import com.split.ai.split.service.model.enums.Role;
-import com.split.ai.split.service.model.enums.SettleMode;
 import com.split.ai.split.service.model.request.group.AddUserToGroupRequest;
 import com.split.ai.split.service.model.request.group.CreateGroupRequest;
 import com.split.ai.split.service.model.request.group.DeleteGroupRequest;
@@ -14,10 +11,8 @@ import com.split.ai.split.service.model.request.group.RemoveUserFromGroupRequest
 import com.split.ai.split.service.model.request.group.ToggleGroupSettleMode;
 import com.split.ai.split.service.model.request.group.UpdateGroupRequest;
 import com.split.ai.split.service.model.request.user.UserRoleData;
-import com.split.ai.split.service.model.response.expense.ExpenseResponse;
 import com.split.ai.split.service.model.response.group.GroupExpenseResponse;
 import com.split.ai.split.service.model.response.group.GroupUserResponse;
-import com.split.ai.split.service.model.response.user.UserGroupResponse;
 import com.split.ai.split.service.repository.dao.IExpenseDao;
 import com.split.ai.split.service.repository.dao.IGroupDao;
 import com.split.ai.split.service.repository.dao.IUserGroupDao;
@@ -30,7 +25,6 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * Service handling group operations.
@@ -49,45 +43,19 @@ public class GroupService implements IGroupService {
         log.info("[GroupService : getGroupDetails] : {}", groupId);
         GroupEntity group = groupDao.findById(groupId);
         if (group == null) {
-            return GroupExpenseResponse.builder().build();
+            return GroupServiceMapper.MAPPER.convert(null, List.of());
         }
-        UserGroupResponse userGroup = UserGroupResponse.builder()
-                .groupId(group.getGroupId())
-                .groupName(group.getGroupName())
-                .groupType(group.getGroupType())
-                .settleMode(group.getSettleMode())
-                .build();
-        List<UserRoleData> members = userGroupDao.findUsersByGroupId(groupId);
         List<ExpenseEntity> expenseEntities = expenseDao.findByGroupId(groupId);
-        List<ExpenseResponse> expenses = expenseEntities.stream()
-                .map(e -> ExpenseResponse.builder()
-                        .expenseId(e.getExpenseId())
-                        .groupId(groupId)
-                        .build())
-                .collect(Collectors.toList());
-        return GroupExpenseResponse.builder()
-                .userGroup(userGroup)
-                .expenses(expenses)
-                .build();
+        return GroupServiceMapper.MAPPER.convert(group, expenseEntities);
     }
 
     @Override
     public void createGroup(CreateGroupRequest request) {
         log.info("[GroupService : createGroup] : {}", request);
-        GroupEntity entity = GroupEntity.builder()
-                .groupId(UUID.randomUUID())
-                .groupName(request.getGroupName())
-                .groupType(request.getGroupType() == null ? GroupType.COMMON : request.getGroupType())
-                .currency(request.getBaseCurrency())
-                .settleMode(SettleMode.NORMAL_SETTLE)
-                .groupStatus(GroupStatus.ACTIVE)
-                .build();
+        GroupEntity entity = GroupServiceMapper.MAPPER.convert(request);
         groupDao.save(entity);
         List<UserRoleData> members = new ArrayList<>();
-        members.add(UserRoleData.builder()
-                .userId(request.getUserInitiated())
-                .role(Role.ADMIN)
-                .build());
+        members.add(GroupServiceMapper.MAPPER.createAdmin(request.getUserInitiated()));
         if (request.getAdditionalUserData() != null) {
             members.addAll(request.getAdditionalUserData());
         }
@@ -109,10 +77,7 @@ public class GroupService implements IGroupService {
     @Override
     public void toggleSettleMode(ToggleGroupSettleMode request) {
         log.info("[GroupService : toggleSettleMode] : {}", request);
-        GroupEntity entity = GroupEntity.builder()
-                .groupId(request.getGroupId())
-                .settleMode(request.getSettleMode())
-                .build();
+        GroupEntity entity = GroupServiceMapper.MAPPER.convert(request);
         groupDao.update(entity);
     }
 
@@ -125,25 +90,14 @@ public class GroupService implements IGroupService {
     @Override
     public void deleteGroup(DeleteGroupRequest request) {
         log.info("[GroupService : deleteGroup] : {}", request);
-        GroupEntity entity = GroupEntity.builder()
-                .groupId(request.getGroupId())
-                .groupStatus(GroupStatus.DELETED)
-                .build();
+        GroupEntity entity = GroupServiceMapper.MAPPER.convert(request);
         groupDao.update(entity);
     }
 
     @Override
     public void updateGroup(UpdateGroupRequest request) {
         log.info("[GroupService : updateGroup] : {}", request);
-        GroupEntity entity = GroupEntity.builder()
-                .groupId(request.getGroupId())
-                .build();
-        if (request.getNewGroupName() != null) {
-            entity.setGroupName(request.getNewGroupName());
-        }
-        if (request.getNewGrouptType() != null) {
-            entity.setGroupType(request.getNewGrouptType());
-        }
+        GroupEntity entity = GroupServiceMapper.MAPPER.convert(request);
         groupDao.update(entity);
     }
 
@@ -157,9 +111,6 @@ public class GroupService implements IGroupService {
     public GroupUserResponse getMembers(UUID groupId) {
         log.info("[GroupService : getMembers] : {}", groupId);
         List<UserRoleData> members = userGroupDao.findUsersByGroupId(groupId);
-        return GroupUserResponse.builder()
-                .groupId(groupId)
-                .groupUserData(members)
-                .build();
+        return GroupServiceMapper.MAPPER.convert(groupId, members);
     }
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/UserService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/UserService.java
@@ -47,20 +47,12 @@ public class UserService implements IUserService {
     public UserSuggestResponse suggestUsers(String query, Integer limit) {
         ValidationUtil.validateSuggestUserQuery(query);
         List<UserEntity> users = userDao.suggestUsers(query, limit);
-        return UserSuggestResponse.builder()
-                .userSuggestDtos(users.stream()
-                        .map(UserServiceMapper.MAPPER::convertToSuggest)
-                        .toList())
-                .build();
+        return UserServiceMapper.MAPPER.convertToSuggestResponse(users);
     }
 
     @Override
     public UserGroupsResponse getGroups(UUID userId, Integer page, Integer size) {
         List<GroupEntity> groups = groupDao.findByUserIdPaginated(userId, page, size);
-        return UserGroupsResponse.builder()
-                .userGroups(groups.stream()
-                        .map(UserServiceMapper.MAPPER::convert)
-                        .toList())
-                .build();
+        return UserServiceMapper.MAPPER.convertToGroupsResponse(groups);
     }
 }


### PR DESCRIPTION
## Summary
- create `randomUUID` helper in `BaseServiceMapper`
- refactor `UserServiceMapper` to build response wrappers
- implement comprehensive `GroupServiceMapper` and remove builders in services

## Testing
- `mvn -q -pl split-service-core -am test` *(fails: Non-resolvable parent POM – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f76ab9f508322876b7f0f17a2563c