### PR TITLE
fix(repository): fetch current revision in findByGroupId to avoid N+1

### DIFF
--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/ExpenseDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/ExpenseDao.java
@@ -26,10 +26,13 @@ public class ExpenseDao implements IExpenseDao {
     public List<ExpenseEntity> findByGroupId(UUID groupId) {
         log.debug("[ExpenseDao : findByGroupId] : {}", groupId);
         try {
-            String sql = "SELECT * FROM expenses WHERE groupId = :groupId";
+            String jpql = "SELECT e FROM ExpenseEntity e " +
+                    "JOIN FETCH e.currentRevision " +
+                    "JOIN FETCH e.group g " +
+                    "WHERE g.groupId = :groupId";
             Map<String, Object> params = new HashMap<>();
             params.put("groupId", groupId);
-            return postgresClient.queryNative(sql, params, ExpenseEntity.class);
+            return postgresClient.query(jpql, params, ExpenseEntity.class);
         } catch (Exception e) {
             log.error("[ExpenseDao : findByGroupId] : error fetching expenses for group {}", groupId, e);
             throw new RuntimeException(e);


### PR DESCRIPTION
## Summary
- load current expense revision and group in single query to eliminate N+1

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for split.ai:split-service:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM @ line 16, column 13)*

------
https://chatgpt.com/codex/tasks/task_e_688f83ac262c8322838104886959ce5c