### PR TITLE
feat: integrate expense and settlement services

### DIFF
--- a/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/ExpenseServiceMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/ExpenseServiceMapper.java
@@ -1,10 +1,144 @@
 package com.split.ai.split.service.core.mapper;
 
+import com.split.ai.split.service.model.request.expense.CreateExpenseRequest;
+import com.split.ai.split.service.model.request.expense.DeleteExpenseRequest;
+import com.split.ai.split.service.model.request.expense.UpdateExpenseRequest;
+import com.split.ai.split.service.model.request.expense.UserExpenseData;
+import com.split.ai.split.service.model.response.expense.ExpenseEditDto;
+import com.split.ai.split.service.model.response.expense.ExpenseHistoryResponse;
+import com.split.ai.split.service.model.response.expense.ExpenseResponse;
+import com.split.ai.split.service.model.response.user.UserExpenseDto;
+import com.split.ai.split.service.repository.entity.ExpenseEntity;
+import com.split.ai.split.service.repository.entity.ExpenseRevisionEntity;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Mapper
 public interface ExpenseServiceMapper extends BaseServiceMapper {
 
     ExpenseServiceMapper MAPPER = Mappers.getMapper(ExpenseServiceMapper.class);
+
+    @Mapping(target = "expenseRevisionId", source = "request", qualifiedByName = "randomUUID")
+    @Mapping(target = "expenseId", expression = "java(expenseId.toString())")
+    @Mapping(target = "editedUserId", source = "payerId")
+    @Mapping(target = "payerId", source = "payerId")
+    @Mapping(target = "amount", source = "amount")
+    @Mapping(target = "expenseDate", expression = "java(System.currentTimeMillis())")
+    @Mapping(target = "splitMode", source = "splitMode")
+    @Mapping(target = "currency", source = "currency")
+    @Mapping(target = "category", source = "category")
+    @Mapping(target = "subCategory", source = "subCategory")
+    @Mapping(target = "expenseStatus", expression = "java(com.split.ai.split.service.model.enums.ExpenseStatus.PENDING)")
+    @Mapping(target = "description", source = "description")
+    @Mapping(target = "userShares", source = "userExpenseDetails", qualifiedByName = "mapUserExpenseDto")
+    ExpenseRevisionEntity toRevisionEntity(CreateExpenseRequest request, UUID expenseId);
+
+    @Mapping(target = "expenseId", source = "expenseId")
+    @Mapping(target = "groupId", source = "request.groupId")
+    @Mapping(target = "currentRevision", source = "revision")
+    ExpenseEntity toExpenseEntity(UUID expenseId, CreateExpenseRequest request, ExpenseRevisionEntity revision);
+
+    @Mapping(target = "expenseRevisionId", source = "request", qualifiedByName = "randomUUID")
+    @Mapping(target = "expenseId", expression = "java(request.getExpenseId().toString())")
+    @Mapping(target = "editedUserId", source = "editedBy")
+    @Mapping(target = "payerId", source = "payer")
+    @Mapping(target = "amount", source = "amount")
+    @Mapping(target = "expenseDate", source = "expenseDate")
+    @Mapping(target = "splitMode", source = "splitMode")
+    @Mapping(target = "currency", source = "currency")
+    @Mapping(target = "category", source = "category")
+    @Mapping(target = "subCategory", source = "subCategory")
+    @Mapping(target = "expenseStatus", expression = "java(com.split.ai.split.service.model.enums.ExpenseStatus.PENDING)")
+    @Mapping(target = "description", source = "description")
+    @Mapping(target = "metaData", source = "metaData")
+    @Mapping(target = "userShares", source = "userExpenseDetails", qualifiedByName = "mapUserExpenseData")
+    ExpenseRevisionEntity toRevisionEntity(UpdateExpenseRequest request);
+
+    @Mapping(target = "expenseRevisionId", source = "current", qualifiedByName = "randomUUID")
+    @Mapping(target = "expenseId", source = "current.expenseId")
+    @Mapping(target = "editedUserId", source = "request.userId")
+    @Mapping(target = "payerId", source = "current.payerId")
+    @Mapping(target = "amount", source = "current.amount")
+    @Mapping(target = "expenseDate", source = "current.expenseDate")
+    @Mapping(target = "splitMode", source = "current.splitMode")
+    @Mapping(target = "currency", source = "current.currency")
+    @Mapping(target = "category", source = "current.category")
+    @Mapping(target = "subCategory", source = "current.subCategory")
+    @Mapping(target = "expenseStatus", expression = "java(com.split.ai.split.service.model.enums.ExpenseStatus.CANCELLED)")
+    @Mapping(target = "description", source = "current.description")
+    @Mapping(target = "metaData", source = "current.metaData")
+    @Mapping(target = "userShares", source = "current.userShares")
+    ExpenseRevisionEntity toDeleteRevision(ExpenseRevisionEntity current, DeleteExpenseRequest request);
+
+    @Mapping(target = "expenseId", source = "expenseId")
+    @Mapping(target = "currentRevision", source = "revision")
+    ExpenseEntity toExpenseEntity(UUID expenseId, ExpenseRevisionEntity revision);
+
+    @Mapping(target = "expenseId", source = "expense.expenseId")
+    @Mapping(target = "groupId", source = "expense.groupId")
+    @Mapping(target = "payerId", source = "currentRevision.payerId")
+    @Mapping(target = "amount", source = "currentRevision.amount")
+    @Mapping(target = "description", source = "currentRevision.description")
+    @Mapping(target = "splitMode", source = "currentRevision.splitMode")
+    @Mapping(target = "currency", source = "currentRevision.currency")
+    @Mapping(target = "category", source = "currentRevision.category")
+    @Mapping(target = "subCategory", source = "currentRevision.subCategory")
+    @Mapping(target = "expenseStatus", source = "currentRevision.expenseStatus")
+    @Mapping(target = "createdAt", source = "expense.createdAt")
+    @Mapping(target = "userExpenseDetails", source = "currentRevision.userShares", qualifiedByName = "mapUserSharesToDtos")
+    ExpenseResponse toExpenseResponse(ExpenseEntity expense);
+
+    @Mapping(target = "expenseEditList", source = "revisions")
+    ExpenseHistoryResponse toHistoryResponse(List<ExpenseRevisionEntity> revisions);
+
+    @Mapping(target = "editedBy", source = "editedUserId")
+    @Mapping(target = "payerNew", source = "payerId")
+    @Mapping(target = "amountNew", source = "amount")
+    @Mapping(target = "expenseDateNew", source = "expenseDate")
+    @Mapping(target = "splitModeNew", source = "splitMode")
+    @Mapping(target = "currencyNew", source = "currency")
+    @Mapping(target = "categoryNew", source = "category")
+    @Mapping(target = "subCategoryNew", source = "subCategory")
+    @Mapping(target = "descriptionNew", source = "description")
+    @Mapping(target = "metaDataNew", source = "metaData")
+    @Mapping(target = "userSharesNew", source = "userShares")
+    ExpenseEditDto toExpenseEditDto(ExpenseRevisionEntity entity);
+
+    @Named("mapUserExpenseDto")
+    default Map<UUID, BigDecimal> mapUserExpenseDto(List<UserExpenseDto> details) {
+        if (details == null) {
+            return new HashMap<>();
+        }
+        return details.stream().collect(Collectors.toMap(UserExpenseDto::getUserId, UserExpenseDto::getSharedAmount));
+    }
+
+    @Named("mapUserExpenseData")
+    default Map<UUID, BigDecimal> mapUserExpenseData(List<UserExpenseData> details) {
+        if (details == null) {
+            return new HashMap<>();
+        }
+        return details.stream().collect(Collectors.toMap(d -> UUID.fromString(d.getUserId()), UserExpenseData::getSharedAmount));
+    }
+
+    @Named("mapUserSharesToDtos")
+    default List<UserExpenseDto> mapUserSharesToDtos(Map<UUID, BigDecimal> shares) {
+        if (shares == null) {
+            return null;
+        }
+        return shares.entrySet().stream()
+                .map(e -> UserExpenseDto.builder()
+                        .userId(e.getKey())
+                        .sharedAmount(e.getValue())
+                        .build())
+                .collect(Collectors.toList());
+    }
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/SettlementServiceMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/SettlementServiceMapper.java
@@ -1,10 +1,33 @@
 package com.split.ai.split.service.core.mapper;
 
+import com.split.ai.split.service.model.request.settlement.SettlementRequest;
+import com.split.ai.split.service.model.response.settlement.SettlementResponse;
+import com.split.ai.split.service.repository.entity.SettlementEntity;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
 public interface SettlementServiceMapper extends BaseServiceMapper {
 
     SettlementServiceMapper MAPPER = Mappers.getMapper(SettlementServiceMapper.class);
+
+    @Mapping(target = "settlementId", source = "request", qualifiedByName = "randomUUID")
+    @Mapping(target = "groupId", source = "groupId")
+    @Mapping(target = "fromUserId", source = "payerId")
+    @Mapping(target = "toUserId", source = "receiverId")
+    @Mapping(target = "amount", source = "amount")
+    @Mapping(target = "currencyType", source = "currency")
+    @Mapping(target = "createdAt", expression = "java(System.currentTimeMillis())")
+    SettlementEntity toEntity(SettlementRequest request);
+
+    @Mapping(target = "settlementId", source = "settlementId")
+    @Mapping(target = "groupId", source = "groupId")
+    @Mapping(target = "fromUser", source = "fromUserId")
+    @Mapping(target = "toUser", source = "toUserId")
+    @Mapping(target = "amount", source = "amount")
+    @Mapping(target = "currencyType", source = "currencyType")
+    @Mapping(target = "note", source = "note")
+    @Mapping(target = "createdAt", source = "createdAt")
+    SettlementResponse toResponse(SettlementEntity entity);
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/ExpenseService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/ExpenseService.java
@@ -1,11 +1,15 @@
 package com.split.ai.split.service.core.service.impl;
 
+import com.split.ai.split.service.core.mapper.ExpenseServiceMapper;
 import com.split.ai.split.service.core.service.IExpenseService;
 import com.split.ai.split.service.model.request.expense.CreateExpenseRequest;
 import com.split.ai.split.service.model.request.expense.DeleteExpenseRequest;
 import com.split.ai.split.service.model.request.expense.UpdateExpenseRequest;
 import com.split.ai.split.service.model.response.expense.ExpenseHistoryResponse;
 import com.split.ai.split.service.model.response.expense.ExpenseResponse;
+import com.split.ai.split.service.repository.dao.IExpenseDao;
+import com.split.ai.split.service.repository.entity.ExpenseEntity;
+import com.split.ai.split.service.repository.entity.ExpenseRevisionEntity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,28 +24,50 @@ import java.util.UUID;
 @Slf4j
 public class ExpenseService implements IExpenseService {
 
+    private final IExpenseDao expenseDao;
+
     @Override
     public ExpenseResponse getExpense(UUID expenseId) {
-        return new ExpenseResponse();
+        log.info("[ExpenseService : getExpense] : {}", expenseId);
+        ExpenseEntity entity = expenseDao.findById(expenseId);
+        return entity == null ? null : ExpenseServiceMapper.MAPPER.toExpenseResponse(entity);
     }
 
     @Override
     public void createExpense(CreateExpenseRequest request) {
-        // no-op
+        log.info("[ExpenseService : createExpense] : {}", request);
+        UUID expenseId = UUID.randomUUID();
+        ExpenseRevisionEntity revision = ExpenseServiceMapper.MAPPER.toRevisionEntity(request, expenseId);
+        expenseDao.saveRevision(revision);
+        ExpenseEntity entity = ExpenseServiceMapper.MAPPER.toExpenseEntity(expenseId, request, revision);
+        expenseDao.save(entity);
     }
 
     @Override
     public void updateExpense(UpdateExpenseRequest request) {
-        // no-op
+        log.info("[ExpenseService : updateExpense] : {}", request);
+        ExpenseRevisionEntity revision = ExpenseServiceMapper.MAPPER.toRevisionEntity(request);
+        expenseDao.saveRevision(revision);
+        ExpenseEntity entity = ExpenseServiceMapper.MAPPER.toExpenseEntity(request.getExpenseId(), revision);
+        expenseDao.update(entity);
     }
 
     @Override
     public void deleteExpense(DeleteExpenseRequest request) {
-        // no-op
+        log.info("[ExpenseService : deleteExpense] : {}", request);
+        ExpenseEntity existing = expenseDao.findById(request.getExpenseId());
+        if (existing == null) {
+            return;
+        }
+        ExpenseRevisionEntity revision = ExpenseServiceMapper.MAPPER.toDeleteRevision(existing.getCurrentRevision(), request);
+        expenseDao.saveRevision(revision);
+        ExpenseEntity entity = ExpenseServiceMapper.MAPPER.toExpenseEntity(request.getExpenseId(), revision);
+        expenseDao.update(entity);
     }
 
     @Override
     public ExpenseHistoryResponse getHistory(UUID expenseId) {
-        return new ExpenseHistoryResponse();
+        log.info("[ExpenseService : getHistory] : {}", expenseId);
+        return ExpenseServiceMapper.MAPPER.toHistoryResponse(expenseDao.findRevisions(expenseId));
     }
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/SettlementService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/SettlementService.java
@@ -1,8 +1,11 @@
 package com.split.ai.split.service.core.service.impl;
 
+import com.split.ai.split.service.core.mapper.SettlementServiceMapper;
 import com.split.ai.split.service.core.service.ISettlementService;
 import com.split.ai.split.service.model.request.settlement.SettlementRequest;
 import com.split.ai.split.service.model.response.settlement.SettlementResponse;
+import com.split.ai.split.service.repository.dao.ISettlementDao;
+import com.split.ai.split.service.repository.entity.SettlementEntity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,13 +20,19 @@ import java.util.UUID;
 @Slf4j
 public class SettlementService implements ISettlementService {
 
+    private final ISettlementDao settlementDao;
+
     @Override
     public void settleUp(SettlementRequest request) {
-        // no-op
+        log.info("[SettlementService : settleUp] : {}", request);
+        SettlementEntity entity = SettlementServiceMapper.MAPPER.toEntity(request);
+        settlementDao.save(entity);
     }
 
     @Override
     public SettlementResponse getSettlement(UUID settlementId) {
-        return new SettlementResponse();
+        log.info("[SettlementService : getSettlement] : {}", settlementId);
+        SettlementEntity entity = settlementDao.findById(settlementId);
+        return entity == null ? null : SettlementServiceMapper.MAPPER.toResponse(entity);
     }
 }

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/IExpenseDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/IExpenseDao.java
@@ -1,11 +1,22 @@
 package com.split.ai.split.service.repository.dao;
 
 import com.split.ai.split.service.repository.entity.ExpenseEntity;
+import com.split.ai.split.service.repository.entity.ExpenseRevisionEntity;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface IExpenseDao {
+
+    void save(ExpenseEntity entity);
+
+    void update(ExpenseEntity entity);
+
+    ExpenseEntity findById(UUID expenseId);
+
+    void saveRevision(ExpenseRevisionEntity entity);
+
+    List<ExpenseRevisionEntity> findRevisions(UUID expenseId);
 
     List<ExpenseEntity> findByGroupId(UUID groupId);
 }

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/ExpenseDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/ExpenseDao.java
@@ -3,6 +3,7 @@ package com.split.ai.split.service.repository.dao.impl;
 import com.split.ai.commons.postgres.PostgresClient;
 import com.split.ai.split.service.repository.dao.IExpenseDao;
 import com.split.ai.split.service.repository.entity.ExpenseEntity;
+import com.split.ai.split.service.repository.entity.ExpenseRevisionEntity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
@@ -21,6 +22,67 @@ import java.util.UUID;
 public class ExpenseDao implements IExpenseDao {
 
     private final PostgresClient postgresClient;
+
+    @Override
+    public void save(ExpenseEntity entity) {
+        log.debug("[ExpenseDao : save] : {}", entity);
+        try {
+            entity.beforeInsertOrUpdate();
+            postgresClient.insert(entity);
+        } catch (Exception e) {
+            log.error("[ExpenseDao : save] : error saving expense {}", entity.getExpenseId(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void update(ExpenseEntity entity) {
+        log.debug("[ExpenseDao : update] : {}", entity);
+        try {
+            entity.beforeInsertOrUpdate();
+            postgresClient.partialUpdate(entity);
+        } catch (Exception e) {
+            log.error("[ExpenseDao : update] : error updating expense {}", entity.getExpenseId(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public ExpenseEntity findById(UUID expenseId) {
+        log.debug("[ExpenseDao : findById] : {}", expenseId);
+        try {
+            return postgresClient.findById(ExpenseEntity.class, expenseId);
+        } catch (Exception e) {
+            log.error("[ExpenseDao : findById] : error fetching expense {}", expenseId, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void saveRevision(ExpenseRevisionEntity entity) {
+        log.debug("[ExpenseDao : saveRevision] : {}", entity);
+        try {
+            entity.beforeInsertOrUpdate();
+            postgresClient.insert(entity);
+        } catch (Exception e) {
+            log.error("[ExpenseDao : saveRevision] : error saving revision for expense {}", entity.getExpenseId(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public List<ExpenseRevisionEntity> findRevisions(UUID expenseId) {
+        log.debug("[ExpenseDao : findRevisions] : {}", expenseId);
+        try {
+            String jpql = "SELECT er FROM ExpenseRevisionEntity er WHERE er.expenseId = :expenseId ORDER BY er.editedAt DESC";
+            Map<String, Object> params = new HashMap<>();
+            params.put("expenseId", expenseId.toString());
+            return postgresClient.query(jpql, params, ExpenseRevisionEntity.class);
+        } catch (Exception e) {
+            log.error("[ExpenseDao : findRevisions] : error fetching revisions for expense {}", expenseId, e);
+            throw new RuntimeException(e);
+        }
+    }
 
     @Override
     public List<ExpenseEntity> findByGroupId(UUID groupId) {

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/SettlementDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/SettlementDao.java
@@ -1,24 +1,56 @@
 package com.split.ai.split.service.repository.dao.impl;
 
+import com.split.ai.commons.postgres.PostgresClient;
 import com.split.ai.split.service.repository.dao.ISettlementDao;
 import com.split.ai.split.service.repository.entity.SettlementEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 
+/**
+ * Data access object for {@link SettlementEntity}.
+ */
+@Repository
+@RequiredArgsConstructor
+@Slf4j
 public class SettlementDao implements ISettlementDao {
+
+    private final PostgresClient postgresClient;
 
     @Override
     public void save(SettlementEntity entity) {
-
+        log.debug("[SettlementDao : save] : {}", entity);
+        try {
+            entity.beforeInsertOrUpdate();
+            postgresClient.insert(entity);
+        } catch (Exception e) {
+            log.error("[SettlementDao : save] : error saving settlement {}", entity.getSettlementId(), e);
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
     public void update(SettlementEntity entity) {
-
+        log.debug("[SettlementDao : update] : {}", entity);
+        try {
+            entity.beforeInsertOrUpdate();
+            postgresClient.partialUpdate(entity);
+        } catch (Exception e) {
+            log.error("[SettlementDao : update] : error updating settlement {}", entity.getSettlementId(), e);
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
     public SettlementEntity findById(UUID settlementId) {
-        return SettlementEntity.builder().build();
+        log.debug("[SettlementDao : findById] : {}", settlementId);
+        try {
+            return postgresClient.findById(SettlementEntity.class, settlementId);
+        } catch (Exception e) {
+            log.error("[SettlementDao : findById] : error fetching settlement {}", settlementId, e);
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement full flow for ExpenseService using DAO layer and mappers
- wire SettlementService to persist and fetch settlements
- add DAO operations with PostgresClient and error handling

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688fb56aea4c8322987fc216c83b0122