### PR TITLE
refactor(core): replace mapper expressions with qualified methods

### DIFF
--- a/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/BaseServiceMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/BaseServiceMapper.java
@@ -2,7 +2,6 @@ package com.split.ai.split.service.core.mapper;
 
 import org.mapstruct.Named;
 
-import java.util.Objects;
 import java.util.UUID;
 
 public interface BaseServiceMapper {
@@ -10,5 +9,15 @@ public interface BaseServiceMapper {
     @Named("randomUUID")
     default UUID randomUUID(Object src) {
         return UUID.randomUUID();
+    }
+
+    @Named("currentEpochTime")
+    default Long currentEpochTime(Object src) {
+        return System.currentTimeMillis();
+    }
+
+    @Named("uuidToString")
+    default String uuidToString(UUID uuid) {
+        return uuid == null ? null : uuid.toString();
     }
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/ExpenseServiceMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/ExpenseServiceMapper.java
@@ -1,5 +1,6 @@
 package com.split.ai.split.service.core.mapper;
 
+import com.split.ai.split.service.model.enums.ExpenseStatus;
 import com.split.ai.split.service.model.request.expense.CreateExpenseRequest;
 import com.split.ai.split.service.model.request.expense.DeleteExpenseRequest;
 import com.split.ai.split.service.model.request.expense.UpdateExpenseRequest;
@@ -28,16 +29,16 @@ public interface ExpenseServiceMapper extends BaseServiceMapper {
     ExpenseServiceMapper MAPPER = Mappers.getMapper(ExpenseServiceMapper.class);
 
     @Mapping(target = "expenseRevisionId", source = "request", qualifiedByName = "randomUUID")
-    @Mapping(target = "expenseId", expression = "java(expenseId.toString())")
+    @Mapping(target = "expenseId", source = "expenseId", qualifiedByName = "uuidToString")
     @Mapping(target = "editedUserId", source = "payerId")
     @Mapping(target = "payerId", source = "payerId")
     @Mapping(target = "amount", source = "amount")
-    @Mapping(target = "expenseDate", expression = "java(System.currentTimeMillis())")
+    @Mapping(target = "expenseDate", source = "request", qualifiedByName = "currentEpochTime")
     @Mapping(target = "splitMode", source = "splitMode")
     @Mapping(target = "currency", source = "currency")
     @Mapping(target = "category", source = "category")
     @Mapping(target = "subCategory", source = "subCategory")
-    @Mapping(target = "expenseStatus", expression = "java(com.split.ai.split.service.model.enums.ExpenseStatus.PENDING)")
+    @Mapping(target = "expenseStatus", source = "request", qualifiedByName = "pendingExpenseStatus")
     @Mapping(target = "description", source = "description")
     @Mapping(target = "userShares", source = "userExpenseDetails", qualifiedByName = "mapUserExpenseDto")
     ExpenseRevisionEntity toRevisionEntity(CreateExpenseRequest request, UUID expenseId);
@@ -48,7 +49,7 @@ public interface ExpenseServiceMapper extends BaseServiceMapper {
     ExpenseEntity toExpenseEntity(UUID expenseId, CreateExpenseRequest request, ExpenseRevisionEntity revision);
 
     @Mapping(target = "expenseRevisionId", source = "request", qualifiedByName = "randomUUID")
-    @Mapping(target = "expenseId", expression = "java(request.getExpenseId().toString())")
+    @Mapping(target = "expenseId", source = "request.expenseId", qualifiedByName = "uuidToString")
     @Mapping(target = "editedUserId", source = "editedBy")
     @Mapping(target = "payerId", source = "payer")
     @Mapping(target = "amount", source = "amount")
@@ -57,7 +58,7 @@ public interface ExpenseServiceMapper extends BaseServiceMapper {
     @Mapping(target = "currency", source = "currency")
     @Mapping(target = "category", source = "category")
     @Mapping(target = "subCategory", source = "subCategory")
-    @Mapping(target = "expenseStatus", expression = "java(com.split.ai.split.service.model.enums.ExpenseStatus.PENDING)")
+    @Mapping(target = "expenseStatus", source = "request", qualifiedByName = "pendingExpenseStatus")
     @Mapping(target = "description", source = "description")
     @Mapping(target = "metaData", source = "metaData")
     @Mapping(target = "userShares", source = "userExpenseDetails", qualifiedByName = "mapUserExpenseData")
@@ -73,7 +74,7 @@ public interface ExpenseServiceMapper extends BaseServiceMapper {
     @Mapping(target = "currency", source = "current.currency")
     @Mapping(target = "category", source = "current.category")
     @Mapping(target = "subCategory", source = "current.subCategory")
-    @Mapping(target = "expenseStatus", expression = "java(com.split.ai.split.service.model.enums.ExpenseStatus.CANCELLED)")
+    @Mapping(target = "expenseStatus", source = "request", qualifiedByName = "cancelledExpenseStatus")
     @Mapping(target = "description", source = "current.description")
     @Mapping(target = "metaData", source = "current.metaData")
     @Mapping(target = "userShares", source = "current.userShares")
@@ -112,6 +113,16 @@ public interface ExpenseServiceMapper extends BaseServiceMapper {
     @Mapping(target = "metaDataNew", source = "metaData")
     @Mapping(target = "userSharesNew", source = "userShares")
     ExpenseEditDto toExpenseEditDto(ExpenseRevisionEntity entity);
+
+    @Named("pendingExpenseStatus")
+    default ExpenseStatus pendingExpenseStatus(Object src) {
+        return ExpenseStatus.PENDING;
+    }
+
+    @Named("cancelledExpenseStatus")
+    default ExpenseStatus cancelledExpenseStatus(Object src) {
+        return ExpenseStatus.CANCELLED;
+    }
 
     @Named("mapUserExpenseDto")
     default Map<UUID, BigDecimal> mapUserExpenseDto(List<UserExpenseDto> details) {

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/GroupServiceMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/GroupServiceMapper.java
@@ -24,7 +24,7 @@ import org.mapstruct.factory.Mappers;
 import java.util.List;
 import java.util.UUID;
 
-@Mapper(imports = {SettleMode.class, GroupStatus.class, Role.class, GroupType.class})
+@Mapper
 public interface GroupServiceMapper extends BaseServiceMapper {
 
     GroupServiceMapper MAPPER = Mappers.getMapper(GroupServiceMapper.class);
@@ -32,8 +32,8 @@ public interface GroupServiceMapper extends BaseServiceMapper {
     @Mapping(target = "groupId", source = "request", qualifiedByName = "randomUUID")
     @Mapping(target = "groupType", source = "groupType", qualifiedByName = "defaultGroupType")
     @Mapping(target = "currency", source = "baseCurrency")
-    @Mapping(target = "settleMode", expression = "java(SettleMode.NORMAL_SETTLE)")
-    @Mapping(target = "groupStatus", expression = "java(GroupStatus.ACTIVE)")
+    @Mapping(target = "settleMode", source = "request", qualifiedByName = "normalSettleMode")
+    @Mapping(target = "groupStatus", source = "request", qualifiedByName = "activeGroupStatus")
     GroupEntity convert(CreateGroupRequest request);
 
     @Mapping(target = "groupId", source = "groupId")
@@ -41,7 +41,7 @@ public interface GroupServiceMapper extends BaseServiceMapper {
     GroupEntity convert(ToggleGroupSettleMode request);
 
     @Mapping(target = "groupId", source = "groupId")
-    @Mapping(target = "groupStatus", expression = "java(GroupStatus.DELETED)")
+    @Mapping(target = "groupStatus", source = "request", qualifiedByName = "deletedGroupStatus")
     GroupEntity convert(DeleteGroupRequest request);
 
     @Mapping(target = "groupId", source = "groupId")
@@ -73,12 +73,32 @@ public interface GroupServiceMapper extends BaseServiceMapper {
     GroupUserResponse convert(UUID groupId, List<UserRoleData> groupUserData);
 
     @Mapping(target = "userId", source = "userId")
-    @Mapping(target = "role", expression = "java(Role.ADMIN)")
+    @Mapping(target = "role", source = "userId", qualifiedByName = "adminRole")
     UserRoleData createAdmin(UUID userId);
 
     @Named("defaultGroupType")
     default GroupType defaultGroupType(GroupType groupType) {
         return groupType == null ? GroupType.COMMON : groupType;
+    }
+
+    @Named("normalSettleMode")
+    default SettleMode normalSettleMode(Object src) {
+        return SettleMode.NORMAL_SETTLE;
+    }
+
+    @Named("activeGroupStatus")
+    default GroupStatus activeGroupStatus(Object src) {
+        return GroupStatus.ACTIVE;
+    }
+
+    @Named("deletedGroupStatus")
+    default GroupStatus deletedGroupStatus(Object src) {
+        return GroupStatus.DELETED;
+    }
+
+    @Named("adminRole")
+    default Role adminRole(Object src) {
+        return Role.ADMIN;
     }
 
     @Named("mapUserShares")

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/SettlementServiceMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/SettlementServiceMapper.java
@@ -18,7 +18,7 @@ public interface SettlementServiceMapper extends BaseServiceMapper {
     @Mapping(target = "toUserId", source = "receiverId")
     @Mapping(target = "amount", source = "amount")
     @Mapping(target = "currencyType", source = "currency")
-    @Mapping(target = "createdAt", expression = "java(System.currentTimeMillis())")
+    @Mapping(target = "createdAt", source = "request", qualifiedByName = "currentEpochTime")
     SettlementEntity toEntity(SettlementRequest request);
 
     @Mapping(target = "settlementId", source = "settlementId")


### PR DESCRIPTION
## Summary
- replace MapStruct expression mappings with `qualifiedByName` methods
- add reusable methods for epoch time and UUID string conversion in base mapper

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for split.ai:split-service:0.0.1-SNAPSHOT; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688fba6509ec8322ba8b17171470d962