### PR TITLE
feat(expense): detail edit history with change dto

### DIFF
--- a/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/ExpenseServiceMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/ExpenseServiceMapper.java
@@ -5,8 +5,6 @@ import com.split.ai.split.service.model.request.expense.CreateExpenseRequest;
 import com.split.ai.split.service.model.request.expense.DeleteExpenseRequest;
 import com.split.ai.split.service.model.request.expense.UpdateExpenseRequest;
 import com.split.ai.split.service.model.request.expense.UserExpenseData;
-import com.split.ai.split.service.model.response.expense.ExpenseEditDto;
-import com.split.ai.split.service.model.response.expense.ExpenseHistoryResponse;
 import com.split.ai.split.service.model.response.expense.ExpenseResponse;
 import com.split.ai.split.service.model.response.user.UserExpenseDto;
 import com.split.ai.split.service.repository.entity.ExpenseEntity;
@@ -97,19 +95,6 @@ public interface ExpenseServiceMapper extends BaseServiceMapper {
     @Mapping(target = "createdAt", source = "expense.createdAt")
     @Mapping(target = "userExpenseDetails", source = "currentRevision.userShares", qualifiedByName = "mapUserSharesToDtos")
     ExpenseResponse toExpenseResponse(ExpenseEntity expense);
-
-    @Mapping(target = "editedBy", source = "editedUserId")
-    @Mapping(target = "payerNew", source = "payerId")
-    @Mapping(target = "amountNew", source = "amount")
-    @Mapping(target = "expenseDateNew", source = "expenseDate")
-    @Mapping(target = "splitModeNew", source = "splitMode")
-    @Mapping(target = "currencyNew", source = "currency")
-    @Mapping(target = "categoryNew", source = "category")
-    @Mapping(target = "subCategoryNew", source = "subCategory")
-    @Mapping(target = "descriptionNew", source = "description")
-    @Mapping(target = "metaDataNew", source = "metaData")
-    @Mapping(target = "userSharesNew", source = "userShares")
-    ExpenseEditDto toExpenseEditDto(ExpenseRevisionEntity entity);
 
     @Named("pendingExpenseStatus")
     default ExpenseStatus pendingExpenseStatus(Object src) {

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/ExpenseService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/ExpenseService.java
@@ -5,6 +5,8 @@ import com.split.ai.split.service.core.service.IExpenseService;
 import com.split.ai.split.service.model.request.expense.CreateExpenseRequest;
 import com.split.ai.split.service.model.request.expense.DeleteExpenseRequest;
 import com.split.ai.split.service.model.request.expense.UpdateExpenseRequest;
+import com.split.ai.split.service.model.response.expense.ChangeDto;
+import com.split.ai.split.service.model.response.expense.ExpenseEditDto;
 import com.split.ai.split.service.model.response.expense.ExpenseHistoryResponse;
 import com.split.ai.split.service.model.response.expense.ExpenseResponse;
 import com.split.ai.split.service.repository.dao.IExpenseDao;
@@ -14,7 +16,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -69,11 +76,52 @@ public class ExpenseService implements IExpenseService {
     @Override
     public ExpenseHistoryResponse getHistory(UUID expenseId) {
         log.info("[ExpenseService : getHistory] : {}", expenseId);
-        List<ExpenseRevisionEntity> expenseRevisionEntityList =  expenseDao.findRevisions(expenseId);
+        List<ExpenseRevisionEntity> revisions = expenseDao.findRevisions(expenseId);
+        List<ExpenseEditDto> edits = new ArrayList<>();
+
+        for (int i = 0; i < revisions.size(); i++) {
+            ExpenseRevisionEntity current = revisions.get(i);
+            ExpenseRevisionEntity previous = i + 1 < revisions.size() ? revisions.get(i + 1) : null;
+
+            Map<String, ChangeDto> changes = new HashMap<>();
+
+            computeChange("payer", previous == null ? null : previous.getPayerId(), current.getPayerId(), changes);
+            computeChange("amount", previous == null ? null : previous.getAmount(), current.getAmount(), changes);
+            computeChange("expenseDate", previous == null ? null : previous.getExpenseDate(), current.getExpenseDate(), changes);
+            computeChange("splitMode", previous == null ? null : previous.getSplitMode(), current.getSplitMode(), changes);
+            computeChange("currency", previous == null ? null : previous.getCurrency(), current.getCurrency(), changes);
+            computeChange("category", previous == null ? null : previous.getCategory(), current.getCategory(), changes);
+            computeChange("subCategory", previous == null ? null : previous.getSubCategory(), current.getSubCategory(), changes);
+            computeChange("description", previous == null ? null : previous.getDescription(), current.getDescription(), changes);
+            computeChange("metaData", previous == null ? null : previous.getMetaData(), current.getMetaData(), changes);
+
+            ExpenseEditDto dto = ExpenseEditDto.builder()
+                    .editedBy(current.getEditedUserId())
+                    .editedAt(current.getEditedAt())
+                    .changes(changes.isEmpty() ? null : changes)
+                    .userSharesOld(previous == null ? null : previous.getUserShares())
+                    .userSharesNew(current.getUserShares())
+                    .build();
+            edits.add(dto);
+        }
+
         return ExpenseHistoryResponse.builder()
-                .expenseEditList(expenseRevisionEntityList.stream()
-                        .map(ExpenseServiceMapper.MAPPER::toExpenseEditDto)
-                        .toList())
+                .expenseEditList(edits)
                 .build();
+    }
+
+    private void computeChange(String key, Object oldVal, Object newVal, Map<String, ChangeDto> changes) {
+        if (!Objects.equals(oldVal, newVal)) {
+            String oldStr = oldVal == null ? null : convertToString(oldVal);
+            String newStr = newVal == null ? null : convertToString(newVal);
+            changes.put(key, ChangeDto.builder().oldValue(oldStr).newValue(newStr).build());
+        }
+    }
+
+    private String convertToString(Object value) {
+        if (value instanceof BigDecimal bd) {
+            return bd.toPlainString();
+        }
+        return value.toString();
     }
 }

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/expense/ChangeDto.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/expense/ChangeDto.java
@@ -9,12 +9,9 @@ import lombok.NoArgsConstructor;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.math.BigDecimal;
-import java.util.Map;
-import java.util.UUID;
 
 /**
- * DTO capturing one edit history entry of an expense.
+ * DTO representing a change with old and new values.
  */
 @NoArgsConstructor
 @AllArgsConstructor
@@ -22,14 +19,10 @@ import java.util.UUID;
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ExpenseEditDto implements Serializable {
+public class ChangeDto implements Serializable {
     @Serial
-    private static final long serialVersionUID = -7338268945012745668L;
+    private static final long serialVersionUID = 3037801079987312055L;
 
-    private UUID editedBy;
-    private Long editedAt;
-
-    private Map<String, ChangeDto> changes;
-    private Map<UUID, BigDecimal> userSharesOld;
-    private Map<UUID, BigDecimal> userSharesNew;
+    private String oldValue;
+    private String newValue;
 }

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/ExpenseDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/ExpenseDao.java
@@ -74,7 +74,8 @@ public class ExpenseDao implements IExpenseDao {
     public List<ExpenseRevisionEntity> findRevisions(UUID expenseId) {
         log.debug("[ExpenseDao : findRevisions] : {}", expenseId);
         try {
-            String jpql = "SELECT er FROM ExpenseRevisionEntity er WHERE er.expenseId = :expenseId ORDER BY er.editedAt DESC";
+            String jpql = "SELECT er FROM ExpenseRevisionEntity er WHERE er.expenseId = :expenseId " +
+                    "ORDER BY er.editedAt DESC"; // ensure latest revisions come first
             Map<String, Object> params = new HashMap<>();
             params.put("expenseId", expenseId.toString());
             return postgresClient.query(jpql, params, ExpenseRevisionEntity.class);


### PR DESCRIPTION
## Summary
- add ChangeDto to represent field changes in expense history
- compute sliding window diffs for expense revisions
- ensure revision lookup returns newest first

## Testing
- `mvn -q test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6890f83e16508322ab5c0ed2a8c6f7e8