### PR TITLE
feat(group): enforce admin role for group operations

### DIFF
--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/GroupService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/GroupService.java
@@ -10,6 +10,7 @@ import com.split.ai.split.service.model.request.group.LeaveGroupRequest;
 import com.split.ai.split.service.model.request.group.RemoveUserFromGroupRequest;
 import com.split.ai.split.service.model.request.group.ToggleGroupSettleMode;
 import com.split.ai.split.service.model.request.group.UpdateGroupRequest;
+import com.split.ai.split.service.model.enums.Role;
 import com.split.ai.split.service.model.request.user.UserRoleData;
 import com.split.ai.split.service.model.response.group.GroupExpenseResponse;
 import com.split.ai.split.service.model.response.group.GroupUserResponse;
@@ -65,16 +66,14 @@ public class GroupService implements IGroupService {
     @Override
     public void addUserToGroup(UUID groupId, AddUserToGroupRequest request) {
         log.info("[GroupService : addUserToGroup] : {}", request);
-        // todo: Check if the userInitiated userId have ADMIN ROLE, if not throw exception
-
+        validateAdmin(groupId, request.getUserInitiated());
         userGroupDao.addUsers(groupId, request.getAdditionalUserData());
     }
 
     @Override
     public void removeUser(UUID groupId, RemoveUserFromGroupRequest request) {
         log.info("[GroupService : removeUser] : group {} user {}", groupId, request.getUserToRemove());
-        // todo: Check if the userInitiated have ADMIN role, else throw exception
-
+        validateAdmin(groupId, request.getUserInitiated());
         userGroupDao.removeUser(groupId, request.getUserToRemove());
     }
 
@@ -94,8 +93,7 @@ public class GroupService implements IGroupService {
     @Override
     public void deleteGroup(DeleteGroupRequest request) {
         log.info("[GroupService : deleteGroup] : {}", request);
-        // todo: Check if the userInitiated have ADMIN role, else throw exception
-
+        validateAdmin(request.getGroupId(), request.getUserInitiated());
         GroupEntity entity = GroupServiceMapper.MAPPER.convert(request);
         groupDao.update(entity);
     }
@@ -118,5 +116,12 @@ public class GroupService implements IGroupService {
         log.info("[GroupService : getMembers] : {}", groupId);
         List<UserRoleData> members = userGroupDao.findUsersByGroupId(groupId);
         return GroupServiceMapper.MAPPER.convert(groupId, members);
+    }
+
+    private void validateAdmin(UUID groupId, UUID userId) {
+        UserRoleData data = userGroupDao.findUserRole(groupId, userId);
+        if (data == null || data.getRole() != Role.ADMIN) {
+            throw new RuntimeException("User does not have ADMIN role");
+        }
     }
 }

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/IUserGroupDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/IUserGroupDao.java
@@ -12,4 +12,6 @@ public interface IUserGroupDao {
     void removeUser(UUID groupId, UUID userId);
 
     List<UserRoleData> findUsersByGroupId(UUID groupId);
+
+    UserRoleData findUserRole(UUID groupId, UUID userId);
 }

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/UserGroupDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/UserGroupDao.java
@@ -73,4 +73,20 @@ public class UserGroupDao implements IUserGroupDao {
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    public UserRoleData findUserRole(UUID groupId, UUID userId) {
+        log.debug("[UserGroupDao : findUserRole] : group {} user {}", groupId, userId);
+        try {
+            String sql = "SELECT user_id as \"userId\", role FROM user_group WHERE group_id = :groupId AND user_id = :userId";
+            Map<String, Object> params = new HashMap<>();
+            params.put("groupId", groupId);
+            params.put("userId", userId);
+            List<UserRoleData> result = postgresClient.queryNative(sql, params, UserRoleData.class);
+            return result.isEmpty() ? null : result.get(0);
+        } catch (Exception e) {
+            log.error("[UserGroupDao : findUserRole] : error fetching role for user {} in group {}", userId, groupId, e);
+            throw new RuntimeException(e);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- ensure only group admins can add members, remove members, or delete the group
- expose DAO lookup for a user's role in a group

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for split.ai:split-service:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68964aa2a7808322ba04dbf252792afd