### PR TITLE
feat(auth): add local auth endpoints with argon2 hashing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
 
+        <!-- Password hashing -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
+
         <!-- Lombok – compile-only -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/PasswordConfig.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/PasswordConfig.java
@@ -1,0 +1,15 @@
+package com.split.ai.split.service.core.userauth;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8();
+    }
+}

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/PasswordService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/PasswordService.java
@@ -1,0 +1,49 @@
+package com.split.ai.split.service.core.userauth;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PasswordService {
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${security.password.pepper}")
+    private String pepper;
+
+    public String encode(String rawPassword) {
+        String preHash = hmacSha256(rawPassword);
+        return passwordEncoder.encode(preHash);
+    }
+
+    public boolean matchesAndUpgrade(String rawPassword, String encodedPassword, java.util.function.Consumer<String> upgradeAction) {
+        String preHash = hmacSha256(rawPassword);
+        boolean matches = passwordEncoder.matches(preHash, encodedPassword);
+        if (matches && passwordEncoder.upgradeEncoding(encodedPassword)) {
+            String newEncoded = passwordEncoder.encode(preHash);
+            upgradeAction.accept(newEncoded);
+        }
+        return matches;
+    }
+
+    private String hmacSha256(String value) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(pepper.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            byte[] result = mac.doFinal(value.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(result);
+        } catch (Exception e) {
+            log.error("[PasswordService : hmacSha256] : error while hashing", e);
+            throw new IllegalStateException("Could not hash password", e);
+        }
+    }
+}

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/UserAuthMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/UserAuthMapper.java
@@ -1,0 +1,27 @@
+package com.split.ai.split.service.core.userauth;
+
+import com.split.ai.split.service.core.userauth.model.LoginServiceRequest;
+import com.split.ai.split.service.core.userauth.model.LoginServiceResponse;
+import com.split.ai.split.service.core.userauth.model.LogoutServiceRequest;
+import com.split.ai.split.service.core.userauth.model.SignupServiceRequest;
+import com.split.ai.split.service.core.userauth.model.SignupServiceResponse;
+import com.split.ai.split.service.model.userauth.LoginRequest;
+import com.split.ai.split.service.model.userauth.LoginResponse;
+import com.split.ai.split.service.model.userauth.LogoutRequest;
+import com.split.ai.split.service.model.userauth.SignupRequest;
+import com.split.ai.split.service.model.userauth.SignupResponse;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface UserAuthMapper {
+
+    SignupServiceRequest toServiceRequest(SignupRequest request);
+
+    SignupResponse toSignupResponse(SignupServiceResponse response);
+
+    LoginServiceRequest toServiceRequest(LoginRequest request);
+
+    LoginResponse toLoginResponse(LoginServiceResponse response);
+
+    LogoutServiceRequest toServiceRequest(LogoutRequest request);
+}

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/UserAuthService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/UserAuthService.java
@@ -1,0 +1,71 @@
+package com.split.ai.split.service.core.userauth;
+
+import com.split.ai.split.service.core.userauth.model.LoginServiceRequest;
+import com.split.ai.split.service.core.userauth.model.LoginServiceResponse;
+import com.split.ai.split.service.core.userauth.model.LogoutServiceRequest;
+import com.split.ai.split.service.core.userauth.model.SignupServiceRequest;
+import com.split.ai.split.service.core.userauth.model.SignupServiceResponse;
+import com.split.ai.split.service.repository.IdentityDao;
+import com.split.ai.split.service.repository.LocalCredentialsDao;
+import com.split.ai.split.service.repository.entity.IdentityEntity;
+import com.split.ai.split.service.repository.entity.LocalCredentialsEntity;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserAuthService {
+
+    private final IdentityDao identityDao;
+    private final LocalCredentialsDao localCredentialsDao;
+    private final PasswordService passwordService;
+
+    public SignupServiceResponse signup(SignupServiceRequest request) {
+        log.info("[UserAuthService : signup] : userName={}", request.getUserName());
+        IdentityEntity identityEntity = IdentityEntity.builder()
+            .userName(request.getUserName())
+            .emailId(request.getEmailId())
+            .build();
+        identityEntity = identityDao.save(identityEntity);
+
+        String encodedPassword = passwordService.encode(request.getPassword());
+        LocalCredentialsEntity credentialsEntity = LocalCredentialsEntity.builder()
+            .identity(identityEntity)
+            .passwordHash(encodedPassword)
+            .build();
+        localCredentialsDao.save(credentialsEntity);
+
+        return SignupServiceResponse.builder()
+            .userId(identityEntity.getId())
+            .userName(identityEntity.getUserName())
+            .build();
+    }
+
+    public LoginServiceResponse login(LoginServiceRequest request) {
+        log.info("[UserAuthService : login] : identifier={}", request.getIdentifier());
+        Optional<IdentityEntity> identityOpt = identityDao.findByUserNameOrEmailId(request.getIdentifier(), request.getIdentifier());
+        IdentityEntity identityEntity = identityOpt.orElseThrow(() -> new IllegalArgumentException("Invalid credentials"));
+        LocalCredentialsEntity credentialsEntity = localCredentialsDao.findByIdentityId(identityEntity.getId())
+            .orElseThrow(() -> new IllegalArgumentException("Invalid credentials"));
+
+        boolean matches = passwordService.matchesAndUpgrade(request.getPassword(), credentialsEntity.getPasswordHash(), newHash -> {
+            credentialsEntity.setPasswordHash(newHash);
+            localCredentialsDao.save(credentialsEntity);
+        });
+        if (!matches) {
+            throw new IllegalArgumentException("Invalid credentials");
+        }
+
+        return LoginServiceResponse.builder()
+            .userId(identityEntity.getId())
+            .userName(identityEntity.getUserName())
+            .build();
+    }
+
+    public void logout(LogoutServiceRequest request) {
+        log.info("[UserAuthService : logout] : noop");
+    }
+}

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/model/LoginServiceRequest.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/model/LoginServiceRequest.java
@@ -1,0 +1,17 @@
+package com.split.ai.split.service.core.userauth.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginServiceRequest {
+
+    private String identifier;
+    private String password;
+    private Boolean rememberMe;
+}

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/model/LoginServiceResponse.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/model/LoginServiceResponse.java
@@ -1,0 +1,17 @@
+package com.split.ai.split.service.core.userauth.model;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginServiceResponse {
+
+    private UUID userId;
+    private String userName;
+}

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/model/LogoutServiceRequest.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/model/LogoutServiceRequest.java
@@ -1,0 +1,9 @@
+package com.split.ai.split.service.core.userauth.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LogoutServiceRequest {
+}

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/model/SignupServiceRequest.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/model/SignupServiceRequest.java
@@ -1,0 +1,17 @@
+package com.split.ai.split.service.core.userauth.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupServiceRequest {
+
+    private String userName;
+    private String emailId;
+    private String password;
+}

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/model/SignupServiceResponse.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/userauth/model/SignupServiceResponse.java
@@ -1,0 +1,17 @@
+package com.split.ai.split.service.core.userauth.model;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupServiceResponse {
+
+    private UUID userId;
+    private String userName;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/userauth/LoginRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/userauth/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.split.ai.split.service.model.userauth;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+
+    @NotBlank
+    private String identifier;
+
+    @NotBlank
+    private String password;
+
+    private Boolean rememberMe;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/userauth/LoginResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/userauth/LoginResponse.java
@@ -1,0 +1,17 @@
+package com.split.ai.split.service.model.userauth;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+
+    private UUID userId;
+    private String userName;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/userauth/LogoutRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/userauth/LogoutRequest.java
@@ -1,0 +1,7 @@
+package com.split.ai.split.service.model.userauth;
+
+import lombok.Data;
+
+@Data
+public class LogoutRequest {
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/userauth/SignupRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/userauth/SignupRequest.java
@@ -1,0 +1,23 @@
+package com.split.ai.split.service.model.userauth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupRequest {
+
+    @NotBlank
+    private String userName;
+
+    @Email
+    @NotBlank
+    private String emailId;
+
+    @NotBlank
+    private String password;
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/userauth/SignupResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/userauth/SignupResponse.java
@@ -1,0 +1,17 @@
+package com.split.ai.split.service.model.userauth;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupResponse {
+
+    private UUID userId;
+    private String userName;
+}

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/IdentityDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/IdentityDao.java
@@ -1,0 +1,44 @@
+package com.split.ai.split.service.repository;
+
+import com.split.ai.split.service.repository.entity.IdentityEntity;
+import com.split.ai.split.service.repository.jpa.IdentityJpaRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class IdentityDao {
+
+    private final IdentityJpaRepository identityJpaRepository;
+
+    public IdentityEntity save(IdentityEntity identityEntity) {
+        try {
+            return identityJpaRepository.save(identityEntity);
+        } catch (Exception e) {
+            log.error("[IdentityDao : save] : error saving identity {}", identityEntity, e);
+            throw e;
+        }
+    }
+
+    public Optional<IdentityEntity> findByUserNameOrEmailId(String userName, String emailId) {
+        try {
+            return identityJpaRepository.findByUserNameOrEmailId(userName, emailId);
+        } catch (Exception e) {
+            log.error("[IdentityDao : findByUserNameOrEmailId] : error finding identity {}", userName, e);
+            throw e;
+        }
+    }
+
+    public Optional<IdentityEntity> findById(UUID id) {
+        try {
+            return identityJpaRepository.findById(id);
+        } catch (Exception e) {
+            log.error("[IdentityDao : findById] : error finding identity {}", id, e);
+            throw e;
+        }
+    }
+}

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/LocalCredentialsDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/LocalCredentialsDao.java
@@ -1,0 +1,35 @@
+package com.split.ai.split.service.repository;
+
+import com.split.ai.split.service.repository.entity.LocalCredentialsEntity;
+import com.split.ai.split.service.repository.jpa.LocalCredentialsJpaRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class LocalCredentialsDao {
+
+    private final LocalCredentialsJpaRepository localCredentialsJpaRepository;
+
+    public LocalCredentialsEntity save(LocalCredentialsEntity entity) {
+        try {
+            return localCredentialsJpaRepository.save(entity);
+        } catch (Exception e) {
+            log.error("[LocalCredentialsDao : save] : error saving credentials for identity {}", entity.getIdentity().getId(), e);
+            throw e;
+        }
+    }
+
+    public Optional<LocalCredentialsEntity> findByIdentityId(UUID identityId) {
+        try {
+            return localCredentialsJpaRepository.findByIdentityId(identityId);
+        } catch (Exception e) {
+            log.error("[LocalCredentialsDao : findByIdentityId] : error finding credentials for identity {}", identityId, e);
+            throw e;
+        }
+    }
+}

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/IdentityEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/IdentityEntity.java
@@ -1,0 +1,51 @@
+package com.split.ai.split.service.repository.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "identity")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IdentityEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id")
+    private UUID id;
+
+    @Column(name = "user_name", nullable = false, unique = true)
+    private String userName;
+
+    @Column(name = "email_id", nullable = false, unique = true)
+    private String emailId;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @PrePersist
+    @PreUpdate
+    public void beforeInsertOrUpdate() {
+        Instant now = Instant.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        updatedAt = now;
+    }
+}

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/LocalCredentialsEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/LocalCredentialsEntity.java
@@ -1,0 +1,54 @@
+package com.split.ai.split.service.repository.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "local_credentials")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocalCredentialsEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id")
+    private UUID id;
+
+    @OneToOne
+    @JoinColumn(name = "identity_id", nullable = false, unique = true)
+    private IdentityEntity identity;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @PrePersist
+    @PreUpdate
+    public void beforeInsertOrUpdate() {
+        Instant now = Instant.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        updatedAt = now;
+    }
+}

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/jpa/IdentityJpaRepository.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/jpa/IdentityJpaRepository.java
@@ -1,0 +1,10 @@
+package com.split.ai.split.service.repository.jpa;
+
+import com.split.ai.split.service.repository.entity.IdentityEntity;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IdentityJpaRepository extends JpaRepository<IdentityEntity, UUID> {
+    Optional<IdentityEntity> findByUserNameOrEmailId(String userName, String emailId);
+}

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/jpa/LocalCredentialsJpaRepository.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/jpa/LocalCredentialsJpaRepository.java
@@ -1,0 +1,10 @@
+package com.split.ai.split.service.repository.jpa;
+
+import com.split.ai.split.service.repository.entity.LocalCredentialsEntity;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LocalCredentialsJpaRepository extends JpaRepository<LocalCredentialsEntity, UUID> {
+    Optional<LocalCredentialsEntity> findByIdentityId(UUID identityId);
+}

--- a/split-service-server/src/main/java/com/split/ai/split/service/server/SplitServiceServerApplication.java
+++ b/split-service-server/src/main/java/com/split/ai/split/service/server/SplitServiceServerApplication.java
@@ -1,0 +1,12 @@
+package com.split.ai.split.service.server;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SplitServiceServerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SplitServiceServerApplication.class, args);
+    }
+}

--- a/split-service-server/src/main/java/com/split/ai/split/service/server/userauth/UserAuthController.java
+++ b/split-service-server/src/main/java/com/split/ai/split/service/server/userauth/UserAuthController.java
@@ -1,0 +1,48 @@
+package com.split.ai.split.service.server.userauth;
+
+import com.split.ai.split.service.core.userauth.UserAuthMapper;
+import com.split.ai.split.service.core.userauth.UserAuthService;
+import com.split.ai.split.service.core.userauth.model.LoginServiceResponse;
+import com.split.ai.split.service.core.userauth.model.SignupServiceResponse;
+import com.split.ai.split.service.model.userauth.LoginRequest;
+import com.split.ai.split.service.model.userauth.LoginResponse;
+import com.split.ai.split.service.model.userauth.LogoutRequest;
+import com.split.ai.split.service.model.userauth.SignupRequest;
+import com.split.ai.split.service.model.userauth.SignupResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/user-auth")
+@RequiredArgsConstructor
+public class UserAuthController {
+
+    private final UserAuthService userAuthService;
+    private final UserAuthMapper userAuthMapper;
+
+    @PostMapping("/signup")
+    public SignupResponse signup(@Valid @RequestBody SignupRequest request) {
+        log.info("[UserAuthController : signup] : userName={}", request.getUserName());
+        SignupServiceResponse response = userAuthService.signup(userAuthMapper.toServiceRequest(request));
+        return userAuthMapper.toSignupResponse(response);
+    }
+
+    @PostMapping("/login")
+    public LoginResponse login(@Valid @RequestBody LoginRequest request) {
+        log.info("[UserAuthController : login] : identifier={}", request.getIdentifier());
+        LoginServiceResponse response = userAuthService.login(userAuthMapper.toServiceRequest(request));
+        return userAuthMapper.toLoginResponse(response);
+    }
+
+    @PostMapping("/logout")
+    public void logout(@RequestBody LogoutRequest request) {
+        log.info("[UserAuthController : logout] : noop");
+        userAuthService.logout(userAuthMapper.toServiceRequest(request));
+    }
+}

--- a/split-service-server/src/main/resources/application.yml
+++ b/split-service-server/src/main/resources/application.yml
@@ -5,3 +5,7 @@ spring:
     password: ${DB_PASSWORD:password}
     driver-class-name: org.postgresql.Driver
 
+security:
+  password:
+    pepper: ${PASSWORD_PEPPER:defaultPepper}
+


### PR DESCRIPTION
## Summary
- add IdentityEntity and LocalCredentialsEntity for user accounts
- implement Argon2id password hashing with pepper and upgrade encoding
- create signup, login and logout endpoints under /v1/user-auth

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68978703cf0483228724451ded7f2d1a