### PR TITLE
feat(auth): map signup provider and credentials

### DIFF
--- a/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/UserAuthServiceMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/UserAuthServiceMapper.java
@@ -4,6 +4,7 @@ import com.split.ai.split.service.model.request.userauth.SignupRequest;
 import com.split.ai.split.service.model.response.userauth.LoginResponse;
 import com.split.ai.split.service.model.response.userauth.SignupResponse;
 import com.split.ai.split.service.repository.entity.IdentityEntity;
+import com.split.ai.split.service.repository.entity.LocalCredentialsEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -21,4 +22,15 @@ public interface UserAuthServiceMapper extends BaseServiceMapper {
 
     @Mapping(target = "userName", source = "identifier")
     LoginResponse toLoginResponse(IdentityEntity identityEntity);
+
+    @Mapping(target = "identityId", source = "request", qualifiedByName = "randomUUID")
+    @Mapping(target = "userId", source = "userId")
+    @Mapping(target = "provider", source = "request.provider")
+    @Mapping(target = "identifier", source = "request.emailId")
+    IdentityEntity toIdentityEntity(SignupRequest request, UUID userId);
+
+    @Mapping(target = "userId", source = "userId")
+    @Mapping(target = "passwordHash", source = "encodedPassword")
+    @Mapping(target = "hashAlgo", source = "hashAlgo")
+    LocalCredentialsEntity toLocalCredentialsEntity(UUID userId, String encodedPassword, String hashAlgo);
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/UserAuthService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/UserAuthService.java
@@ -35,22 +35,16 @@ public class UserAuthService implements IUserAuthService {
 
     public SignupResponse signup(SignupRequest request) {
         log.info("[UserAuthService : signup] : userName={}", request.getUserName());
+        if (request.getProvider() == null) {
+            request.setProvider(IDENTITY_PROVIDER.LOCAL);
+        }
         UUID userId = UUID.randomUUID();
-        IdentityEntity identityEntity = IdentityEntity.builder()
-                .identityId(UUID.randomUUID())
-                .userId(userId)
-                .provider(IDENTITY_PROVIDER.LOCAL)
-                .identifier(request.getEmailId())
-                .verified(Boolean.FALSE)
-                .build();
+        IdentityEntity identityEntity = UserAuthServiceMapper.MAPPER.toIdentityEntity(request, userId);
         identityDao.save(identityEntity);
 
         String encodedPassword = passwordService.encode(request.getPassword());
-        LocalCredentialsEntity credentialsEntity = LocalCredentialsEntity.builder()
-                .userId(userId)
-                .passwordHash(encodedPassword)
-                .hashAlgo(hashAlgo)
-                .build();
+        LocalCredentialsEntity credentialsEntity = UserAuthServiceMapper.MAPPER
+                .toLocalCredentialsEntity(userId, encodedPassword, hashAlgo);
         localCredentialsDao.save(credentialsEntity);
 
         return UserAuthServiceMapper.MAPPER.toSignupResponse(request, userId);

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/request/userauth/SignupRequest.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/request/userauth/SignupRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.split.ai.split.service.model.enums.IDENTITY_PROVIDER;
 
 @Data
 @NoArgsConstructor
@@ -20,4 +21,6 @@ public class SignupRequest {
 
     @NotBlank
     private String password;
+
+    private IDENTITY_PROVIDER provider = IDENTITY_PROVIDER.LOCAL;
 }


### PR DESCRIPTION
## Summary
- default provider to LOCAL in signup request
- map signup requests to identity and credential entities
- generate identity and credential entities via mapper methods

## Testing
- `mvn -pl split-service-core -am test` *(fails: Non-resolvable parent POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb3ecd3c8322bf460bd2971e1a95