### PR TITLE
feat: add global exception handling infrastructure

### DIFF
--- a/commons/src/main/java/com/split/ai/split/service/commons/exception/ErrorCode.java
+++ b/commons/src/main/java/com/split/ai/split/service/commons/exception/ErrorCode.java
@@ -1,0 +1,49 @@
+package com.split.ai.split.service.commons.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Enumeration of application specific error codes.
+ */
+public enum ErrorCode {
+    GENERIC_ERROR(1000, "An unexpected error occurred", HttpStatus.INTERNAL_SERVER_ERROR),
+    USER_NOT_FOUND(1001, "User not found", HttpStatus.NOT_FOUND);
+
+    private final Integer errorCode;
+    private final String errorMessage;
+    private final HttpStatus httpStatus;
+
+    ErrorCode(Integer errorCode, String errorMessage, HttpStatus httpStatus) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.httpStatus = httpStatus;
+    }
+
+    public Integer getErrorCode() {
+        return errorCode;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    /**
+     * Resolve an {@link ErrorCode} from an integer error code.
+     *
+     * @param code the code to resolve
+     * @return matching {@link ErrorCode}
+     * @throws IllegalArgumentException if no match exists
+     */
+    public static ErrorCode fromCode(Integer code) {
+        for (ErrorCode errorCode : values()) {
+            if (errorCode.errorCode.equals(code)) {
+                return errorCode;
+            }
+        }
+        throw new IllegalArgumentException("Unknown error code: " + code);
+    }
+}

--- a/commons/src/main/java/com/split/ai/split/service/commons/exception/SplitException.java
+++ b/commons/src/main/java/com/split/ai/split/service/commons/exception/SplitException.java
@@ -1,0 +1,29 @@
+package com.split.ai.split.service.commons.exception;
+
+/**
+ * Custom runtime exception carrying application specific error details.
+ */
+public class SplitException extends RuntimeException {
+
+    private final Integer errorCode;
+    private final String message;
+
+    private SplitException(Integer errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+    public static SplitException createException(ErrorCode errorCode) {
+        return new SplitException(errorCode.getErrorCode(), errorCode.getErrorMessage());
+    }
+
+    public Integer getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/error/ErrorResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/error/ErrorResponse.java
@@ -1,0 +1,31 @@
+package com.split.ai.split.service.model.response.error;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * Response returned when an exception occurs.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -4965034822214328909L;
+
+    private Integer errorCode;
+    private String errorMessage;
+    private String timestamp;
+    private String serviceName;
+    private String className;
+    private String methodName;
+    private String rootCause;
+}

--- a/split-service-server/src/main/java/com/split/ai/split/service/server/advice/SplitExceptionAdvice.java
+++ b/split-service-server/src/main/java/com/split/ai/split/service/server/advice/SplitExceptionAdvice.java
@@ -1,0 +1,46 @@
+package com.split.ai.split.service.server.advice;
+
+import com.split.ai.split.service.commons.exception.ErrorCode;
+import com.split.ai.split.service.commons.exception.SplitException;
+import com.split.ai.split.service.model.response.error.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.Instant;
+
+/**
+ * Global handler for {@link SplitException}.
+ */
+@ControllerAdvice
+@Slf4j
+public class SplitExceptionAdvice {
+
+    private static final String SERVICE_NAME = "split-service";
+
+    @ExceptionHandler(SplitException.class)
+    public ResponseEntity<ErrorResponse> handleSplitException(SplitException exception) {
+        log.error("[SplitExceptionAdvice : handleSplitException] : {}", exception.getMessage(), exception);
+        ErrorCode errorCode = ErrorCode.fromCode(exception.getErrorCode());
+        ErrorResponse response = ErrorResponse.builder()
+            .errorCode(errorCode.getErrorCode())
+            .errorMessage(errorCode.getErrorMessage())
+            .timestamp(Instant.now().toString())
+            .serviceName(SERVICE_NAME)
+            .className(getClassName(exception))
+            .methodName(getMethodName(exception))
+            .rootCause(ExceptionUtils.getRootCauseMessage(exception))
+            .build();
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    private String getClassName(Exception exception) {
+        return exception.getStackTrace().length > 0 ? exception.getStackTrace()[0].getClassName() : null;
+    }
+
+    private String getMethodName(Exception exception) {
+        return exception.getStackTrace().length > 0 ? exception.getStackTrace()[0].getMethodName() : null;
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable error code enum and custom SplitException
- return structured ErrorResponse with global SplitExceptionAdvice

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for split.ai:split-service:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898d09a7b2c8322bff16f35c7d36e04