### PR TITLE
chore: add contextual error logs before throwing SplitException

### DIFF
--- a/commons/src/main/java/com/split/ai/commons/postgres/PostgresClientImpl.java
+++ b/commons/src/main/java/com/split/ai/commons/postgres/PostgresClientImpl.java
@@ -10,6 +10,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeanWrapperImpl;
@@ -31,6 +32,7 @@ import java.util.Map;
 @Repository
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class PostgresClientImpl implements PostgresClient {
 
     private static final int DEFAULT_LOCK_TIME = 5;
@@ -148,6 +150,7 @@ public class PostgresClientImpl implements PostgresClient {
         Object id = entityManager.getEntityManagerFactory().getPersistenceUnitUtil().getIdentifier(object);
         T existing = findEntity(cls, id, lockMode, lockTimeout);
         if (existing == null) {
+            log.error("[PostgresClientImpl : doPartialUpdate] : entity {} with id {} not found", cls.getSimpleName(), id);
             throw SplitException.createException(ErrorCode.ENTITY_NOT_FOUND);
         }
         BeanUtils.copyProperties(object, existing, getNullPropertyNames(object));

--- a/commons/src/main/java/com/split/ai/split/service/commons/exception/ErrorCode.java
+++ b/commons/src/main/java/com/split/ai/split/service/commons/exception/ErrorCode.java
@@ -1,10 +1,12 @@
 package com.split.ai.split.service.commons.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 
 /**
  * Enumeration of application specific error codes.
  */
+@Slf4j
 public enum ErrorCode {
     GENERIC_ERROR(1000, "An unexpected error occurred", HttpStatus.INTERNAL_SERVER_ERROR),
     USER_NOT_FOUND(1001, "User not found", HttpStatus.NOT_FOUND),
@@ -52,6 +54,7 @@ public enum ErrorCode {
                 return errorCode;
             }
         }
+        log.error("[ErrorCode : fromCode] : unknown error code {}", code);
         throw SplitException.createException(ErrorCode.INVALID_ERROR_CODE);
     }
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/ExpenseService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/ExpenseService.java
@@ -70,6 +70,7 @@ public class ExpenseService implements IExpenseService {
 
         ExpenseEntity existing = expenseDao.findById(request.getExpenseId());
         if (existing == null) {
+            log.error("[ExpenseService : updateExpense] : expense {} not found", request.getExpenseId());
             throw SplitException.createException(ErrorCode.ENTITY_NOT_FOUND);
         }
 
@@ -79,6 +80,7 @@ public class ExpenseService implements IExpenseService {
         ExpenseRevisionEntity newRevision = updatedFlagAndUpdatedExpenseRevision.getRight();
 
         if (!updated) {
+            log.error("[ExpenseService : updateExpense] : invalid update {}", request);
             throw SplitException.createException(ErrorCode.INVALID_EXPENSE_UPDATE);
         }
 

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/GroupService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/GroupService.java
@@ -123,6 +123,7 @@ public class GroupService implements IGroupService {
     private void validateAdmin(UUID groupId, UUID userId) {
         UserRoleData data = userGroupDao.findUserRole(groupId, userId);
         if (data == null || data.getRole() != ROLE.ADMIN) {
+            log.error("[GroupService : validateAdmin] : user {} unauthorized for group {}", userId, groupId);
             throw SplitException.createException(ErrorCode.UNAUTHORIZED_OPERATION);
         }
     }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/UserAuthService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/UserAuthService.java
@@ -50,15 +50,22 @@ public class UserAuthService implements IUserAuthService {
     public LoginResponse login(LoginRequest request) {
         log.info("[UserAuthService : login] : identifier={}", request.getIdentifier());
         Optional<IdentityEntity> identityOpt = identityDao.findByProviderAndIdentifier(request.getProvider(), request.getIdentifier());
-        IdentityEntity identityEntity = identityOpt.orElseThrow(() -> SplitException.createException(ErrorCode.INVALID_CREDENTIALS));
+        IdentityEntity identityEntity = identityOpt.orElseThrow(() -> {
+            log.error("[UserAuthService : login] : identity not found for provider {} identifier {}", request.getProvider(), request.getIdentifier());
+            return SplitException.createException(ErrorCode.INVALID_CREDENTIALS);
+        });
         LocalCredentialsEntity credentialsEntity = localCredentialsDao.findByUserId(identityEntity.getUserId())
-                .orElseThrow(() -> SplitException.createException(ErrorCode.INVALID_CREDENTIALS));
+                .orElseThrow(() -> {
+                    log.error("[UserAuthService : login] : credentials not found for user {}", identityEntity.getUserId());
+                    return SplitException.createException(ErrorCode.INVALID_CREDENTIALS);
+                });
 
         boolean matches = passwordService.matchesAndUpgrade(request.getPassword(), credentialsEntity.getPasswordHash(), newHash -> {
             credentialsEntity.setPasswordHash(newHash);
             localCredentialsDao.update(credentialsEntity);
         });
         if (!matches) {
+            log.error("[UserAuthService : login] : password mismatch for user {}", identityEntity.getUserId());
             throw SplitException.createException(ErrorCode.INVALID_CREDENTIALS);
         }
 

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/utils/ValidationUtil.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/utils/ValidationUtil.java
@@ -2,6 +2,7 @@ package com.split.ai.split.service.core.utils;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import com.split.ai.split.service.commons.exception.ErrorCode;
 import com.split.ai.split.service.commons.exception.SplitException;
@@ -9,10 +10,12 @@ import com.split.ai.split.service.commons.exception.SplitException;
 import java.util.Objects;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
 public class ValidationUtil {
 
     public static void validateSuggestUserQuery(String query) {
         if (Objects.isNull(query) || query.length() < 2) {
+            log.error("[ValidationUtil : validateSuggestUserQuery] : invalid query {}", query);
             throw SplitException.createException(ErrorCode.INVALID_QUERY);
         }
     }


### PR DESCRIPTION
## Summary
- log invalid error codes before raising SplitException
- include entity ids in PostgresClient error logs
- capture context when user queries or authentication fails

## Testing
- `mvn test` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68994dd7c884832289180c20de6ae679