### PR TITLE
feat: validate splits via SplitEngine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <lombok.version>1.18.38</lombok.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <commons-lang.version>3.17.0</commons-lang.version>
+        <split-engine.version>0.0.1</split-engine.version>
     </properties>
 
     <modules>

--- a/split-service-core/pom.xml
+++ b/split-service-core/pom.xml
@@ -22,6 +22,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.split</groupId>
+            <artifactId>split-engine-jvm</artifactId>
+            <version>${split-engine.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
             <version>${mapstruct.version}</version>

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/engine/SplitEngineAdapter.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/engine/SplitEngineAdapter.java
@@ -1,0 +1,29 @@
+package com.split.ai.split.service.core.engine;
+
+import com.split.ai.split.service.core.utils.MoneyUtil;
+import com.split.ai.split.service.model.request.expense.CreateExpenseRequest;
+import io.split.engine.SplitInput;
+import io.split.engine.SplitMode;
+import io.split.engine.SplitPayload;
+
+import java.util.List;
+
+public final class SplitEngineAdapter {
+    private SplitEngineAdapter() {}
+
+    public static SplitInput toInput(CreateExpenseRequest req, int scale) {
+        List<String> participants = req.getUserExpenseDetails().stream()
+                .map(dto -> dto.getUserId().toString())
+                .toList();
+
+        SplitMode mode = SplitMode.valueOf(req.getSplitMode().name());
+        SplitPayload payload = SplitPayloadFactory.build(req.getSplitMode(), req.getSplitRequest(), participants, scale);
+
+        return new SplitInput(
+                MoneyUtil.toMoney(req.getAmount(), scale),
+                participants,
+                mode,
+                payload
+        );
+    }
+}

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/engine/SplitPayloadFactory.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/engine/SplitPayloadFactory.java
@@ -1,0 +1,66 @@
+package com.split.ai.split.service.core.engine;
+
+import com.split.ai.split.service.core.utils.MoneyUtil;
+import com.split.ai.split.service.model.enums.SPLIT_MODE;
+import com.split.ai.split.service.model.request.split.ExactSplitRequest;
+import com.split.ai.split.service.model.request.split.PercentageSplitRequest;
+import com.split.ai.split.service.model.request.split.RatioSplitRequest;
+import com.split.ai.split.service.model.request.split.SplitRequest;
+import io.split.engine.EqualPayload;
+import io.split.engine.ExactPayload;
+import io.split.engine.PercentPayload;
+import io.split.engine.RatioPayload;
+import io.split.engine.SplitPayload;
+import io.split.engine.UserAmount;
+import io.split.engine.UserBps;
+import io.split.engine.UserRatio;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class SplitPayloadFactory {
+
+    private SplitPayloadFactory() {}
+
+    @FunctionalInterface
+    private interface PayloadBuilder {
+        SplitPayload build(SplitRequest request, List<String> participants, int scale);
+    }
+
+    private static final Map<SPLIT_MODE, PayloadBuilder> BUILDERS = new EnumMap<>(SPLIT_MODE.class);
+
+    static {
+        BUILDERS.put(SPLIT_MODE.EQUAL, (req, participants, scale) -> new EqualPayload(participants));
+        BUILDERS.put(SPLIT_MODE.EXACT, (req, participants, scale) -> {
+            ExactSplitRequest eReq = (ExactSplitRequest) req;
+            List<UserAmount> items = eReq.getUserAmountSplitDtoList().stream()
+                    .map(u -> new UserAmount(u.getUserId().toString(), MoneyUtil.toMoney(u.getAmount(), scale)))
+                    .collect(Collectors.toList());
+            return new ExactPayload(items);
+        });
+        BUILDERS.put(SPLIT_MODE.PERCENTAGE, (req, participants, scale) -> {
+            PercentageSplitRequest pReq = (PercentageSplitRequest) req;
+            List<UserBps> items = pReq.getUserPercentageSplitDtoList().stream()
+                    .map(u -> new UserBps(u.getUserId().toString(), u.getPercentage().movePointRight(2).intValueExact()))
+                    .collect(Collectors.toList());
+            return new PercentPayload(items);
+        });
+        BUILDERS.put(SPLIT_MODE.RATIO, (req, participants, scale) -> {
+            RatioSplitRequest rReq = (RatioSplitRequest) req;
+            List<UserRatio> items = rReq.getUserRatioSplitDtoList().stream()
+                    .map(u -> new UserRatio(u.getUserId().toString(), u.getRatio()))
+                    .collect(Collectors.toList());
+            return new RatioPayload(items);
+        });
+    }
+
+    public static SplitPayload build(SPLIT_MODE mode, SplitRequest request, List<String> participants, int scale) {
+        PayloadBuilder builder = BUILDERS.get(mode);
+        if (builder == null) {
+            throw new IllegalArgumentException("Unsupported split mode: " + mode);
+        }
+        return builder.build(request, participants, scale);
+    }
+}

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/ExpenseService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/ExpenseService.java
@@ -5,8 +5,11 @@ import com.split.ai.split.service.commons.exception.SplitException;
 import com.split.ai.split.service.core.helper.ExpenseHelper;
 import com.split.ai.split.service.core.mapper.ExpenseServiceMapper;
 import com.split.ai.split.service.core.service.IExpenseService;
+import com.split.ai.split.service.core.engine.SplitEngineAdapter;
+import com.split.ai.split.service.core.utils.MoneyUtil;
 import com.split.ai.split.service.model.enums.EXPENSE_REVISION_STATUS;
 import com.split.ai.split.service.model.enums.EXPENSE_STATUS;
+import com.split.ai.split.service.model.enums.CURRENCY;
 import com.split.ai.split.service.model.request.expense.CreateExpenseRequest;
 import com.split.ai.split.service.model.request.expense.DeleteExpenseRequest;
 import com.split.ai.split.service.model.request.expense.UpdateExpenseRequest;
@@ -26,12 +29,18 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
+
+import io.split.engine.Share;
+import io.split.engine.SplitEngineJvm;
+import io.split.engine.SplitInput;
 
 /**
  * Service handling expense operations.
@@ -55,7 +64,7 @@ public class ExpenseService implements IExpenseService {
     @Override
     public void createExpense(CreateExpenseRequest request) {
         log.info("[ExpenseService : createExpense] : {}", request);
-        // todo: SplitEngine logic to verify the userExpenseDetails
+        validateSplit(request);
 
         UUID expenseId = UUID.randomUUID();
         ExpenseRevisionEntity revision = ExpenseServiceMapper.MAPPER.toRevisionEntity(request, expenseId);
@@ -144,6 +153,35 @@ public class ExpenseService implements IExpenseService {
         return ExpenseHistoryResponse.builder()
                 .expenseEditList(edits)
                 .build();
+    }
+
+    private void validateSplit(CreateExpenseRequest request) {
+        int scale = resolveScale(request.getCurrency());
+        SplitInput input = SplitEngineAdapter.toInput(request, scale);
+        List<Share> shares = SplitEngineJvm.computeShares(input);
+
+        Map<String, BigDecimal> expectedMap = shares.stream()
+                .collect(Collectors.toMap(Share::getUserId, s -> MoneyUtil.toBig(s.getOwe())));
+        Map<String, BigDecimal> clientMap = request.getUserExpenseDetails().stream()
+                .collect(Collectors.toMap(dto -> dto.getUserId().toString(), dto -> dto.getSharedAmount().setScale(scale, RoundingMode.UNNECESSARY)));
+
+        if (!expectedMap.keySet().equals(clientMap.keySet())) {
+            log.error("[ExpenseService : validateSplit] : participant mismatch expected {} got {}", expectedMap.keySet(), clientMap.keySet());
+            throw SplitException.createException(ErrorCode.INVALID_QUERY);
+        }
+
+        for (String user : expectedMap.keySet()) {
+            BigDecimal expected = expectedMap.get(user).setScale(scale, RoundingMode.UNNECESSARY);
+            BigDecimal actual = clientMap.get(user);
+            if (expected.compareTo(actual) != 0) {
+                log.error("[ExpenseService : validateSplit] : amount mismatch for user {} expected {} got {}", user, expected, actual);
+                throw SplitException.createException(ErrorCode.INVALID_QUERY);
+            }
+        }
+    }
+
+    private int resolveScale(CURRENCY currency) {
+        return currency == null ? 2 : currency.scale();
     }
 
     private void computeUserShareChanges(Map<UUID, BigDecimal> oldShares, Map<UUID, BigDecimal> newShares, Map<String, ChangeDto> userShareChanges) {

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/utils/MoneyUtil.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/utils/MoneyUtil.java
@@ -1,0 +1,20 @@
+package com.split.ai.split.service.core.utils;
+
+import io.split.engine.Money;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public final class MoneyUtil {
+    private MoneyUtil() {}
+
+    public static Money toMoney(BigDecimal amount, int scale) {
+        BigDecimal normalized = amount.setScale(scale, RoundingMode.UNNECESSARY);
+        long minor = normalized.movePointRight(scale).longValueExact();
+        return new Money(minor, scale);
+    }
+
+    public static BigDecimal toBig(Money money) {
+        return BigDecimal.valueOf(money.getMinor()).movePointLeft(money.getScale());
+    }
+}

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/enums/CURRENCY.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/enums/CURRENCY.java
@@ -1,7 +1,17 @@
 package com.split.ai.split.service.model.enums;
 
 public enum CURRENCY {
-    INR,
-    USD,
-    EUR
+    INR(2),
+    USD(2),
+    EUR(2);
+
+    private final int scale;
+
+    CURRENCY(int scale) {
+        this.scale = scale;
+    }
+
+    public int scale() {
+        return scale;
+    }
 }


### PR DESCRIPTION
## Summary
- validate expense split details using SplitEngine
- add MoneyUtil and factory-based adapter for engine payloads
- support currency scale and configure split-engine dependency

## Testing
- `mvn -q -pl split-service-core -am test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b031a4708322999309c46e905f62