### PR TITLE
feat(repository): add session and refresh token entities

### DIFF
--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/IRefreshTokenDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/IRefreshTokenDao.java
@@ -1,0 +1,16 @@
+package com.split.ai.split.service.repository.dao;
+
+import com.split.ai.split.service.repository.entity.RefreshTokenEntity;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface IRefreshTokenDao {
+
+    RefreshTokenEntity save(RefreshTokenEntity entity);
+
+    void update(RefreshTokenEntity entity);
+
+    Optional<RefreshTokenEntity> findById(UUID refreshTokenId);
+}
+

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/ISessionDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/ISessionDao.java
@@ -1,0 +1,16 @@
+package com.split.ai.split.service.repository.dao;
+
+import com.split.ai.split.service.repository.entity.SessionEntity;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ISessionDao {
+
+    SessionEntity save(SessionEntity entity);
+
+    void update(SessionEntity entity);
+
+    Optional<SessionEntity> findById(UUID sessionId);
+}
+

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/RefreshTokenDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/RefreshTokenDao.java
@@ -1,0 +1,38 @@
+package com.split.ai.split.service.repository.dao.impl;
+
+import com.split.ai.commons.postgres.PostgresClient;
+import com.split.ai.split.service.repository.dao.IRefreshTokenDao;
+import com.split.ai.split.service.repository.entity.RefreshTokenEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenDao implements IRefreshTokenDao {
+
+    private final PostgresClient postgresClient;
+
+    @Override
+    public RefreshTokenEntity save(RefreshTokenEntity entity) {
+        log.debug("[RefreshTokenDao : save] : {}", entity);
+        return postgresClient.insert(entity);
+    }
+
+    @Override
+    public void update(RefreshTokenEntity entity) {
+        log.debug("[RefreshTokenDao : update] : {}", entity);
+        postgresClient.partialUpdate(entity);
+    }
+
+    @Override
+    public Optional<RefreshTokenEntity> findById(UUID refreshTokenId) {
+        log.debug("[RefreshTokenDao : findById] : {}", refreshTokenId);
+        return Optional.ofNullable(postgresClient.findById(RefreshTokenEntity.class, refreshTokenId));
+    }
+}
+

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/SessionDao.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/dao/impl/SessionDao.java
@@ -1,0 +1,40 @@
+package com.split.ai.split.service.repository.dao.impl;
+
+import com.split.ai.commons.postgres.PostgresClient;
+import com.split.ai.split.service.repository.dao.ISessionDao;
+import com.split.ai.split.service.repository.entity.SessionEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class SessionDao implements ISessionDao {
+
+    private final PostgresClient postgresClient;
+
+    @Override
+    public SessionEntity save(SessionEntity entity) {
+        log.debug("[SessionDao : save] : {}", entity);
+        entity.beforeInsert();
+        return postgresClient.insert(entity);
+    }
+
+    @Override
+    public void update(SessionEntity entity) {
+        log.debug("[SessionDao : update] : {}", entity);
+        entity.beforeUpdate();
+        postgresClient.partialUpdate(entity);
+    }
+
+    @Override
+    public Optional<SessionEntity> findById(UUID sessionId) {
+        log.debug("[SessionDao : findById] : {}", sessionId);
+        return Optional.ofNullable(postgresClient.findById(SessionEntity.class, sessionId));
+    }
+}
+

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/RefreshTokenEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/RefreshTokenEntity.java
@@ -1,0 +1,44 @@
+package com.split.ai.split.service.repository.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "auth_refresh_token")
+public class RefreshTokenEntity {
+
+    @Id
+    private UUID refreshTokenId;
+
+    @Column(nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false)
+    private UUID sessionId;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String tokenHash;
+
+    @Column(nullable = false)
+    private Long issuedAt;
+
+    @Column(nullable = false)
+    private Long expiresAt;
+
+    private Long revokedAt;
+
+    private UUID replacedBy;
+}
+

--- a/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/SessionEntity.java
+++ b/split-service-repository/src/main/java/com/split/ai/split/service/repository/entity/SessionEntity.java
@@ -1,0 +1,58 @@
+package com.split.ai.split.service.repository.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "sessions")
+public class SessionEntity {
+
+    @Id
+    private UUID sessionId;
+
+    @Column(nullable = false)
+    private UUID userId;
+
+    @Column(columnDefinition = "TEXT")
+    private String userAgent;
+
+    @Column(columnDefinition = "TEXT")
+    private String ipAddress;
+
+    @Column(nullable = false, updatable = false)
+    private Long createdAt;
+
+    @Column(nullable = false)
+    private Long lastUsedAt;
+
+    private Long revokedAt;
+
+    @PrePersist
+    public void beforeInsert() {
+        long now = System.currentTimeMillis();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        if (lastUsedAt == null) {
+            lastUsedAt = now;
+        }
+    }
+
+    public void beforeUpdate() {
+        lastUsedAt = System.currentTimeMillis();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add refresh token entity mapping and DAO
- introduce session entity with DAO support

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf00d68c4c8322be042cb3c0eab9d5