### PR TITLE
feat: add session-based authentication flow

### DIFF
--- a/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/UserAuthServiceMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/UserAuthServiceMapper.java
@@ -18,9 +18,13 @@ public interface UserAuthServiceMapper extends BaseServiceMapper {
 
     @Mapping(target = "userId", source = "userId")
     @Mapping(target = "userName", source = "request.userName")
+    @Mapping(target = "accessToken", ignore = true)
+    @Mapping(target = "refreshToken", ignore = true)
     SignupResponse toSignupResponse(SignupRequest request, UUID userId);
 
     @Mapping(target = "userName", source = "identifier")
+    @Mapping(target = "accessToken", ignore = true)
+    @Mapping(target = "refreshToken", ignore = true)
     LoginResponse toLoginResponse(IdentityEntity identityEntity);
 
     @Mapping(target = "identityId", source = "request", qualifiedByName = "randomUUID")

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/ITokenService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/ITokenService.java
@@ -1,0 +1,18 @@
+package com.split.ai.split.service.core.service;
+
+import java.util.Map;
+import java.util.UUID;
+
+public interface ITokenService {
+
+    String generateAccessToken(UUID userId, UUID sessionId, int tokenVersion);
+
+    String generateRefreshToken(UUID refreshTokenId, UUID userId, UUID sessionId, int tokenVersion);
+
+    Map<String, Object> parseAccessToken(String token);
+
+    Map<String, Object> parseRefreshToken(String token);
+
+    String hashToken(String token);
+}
+

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/IUserAuthService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/IUserAuthService.java
@@ -1,7 +1,6 @@
 package com.split.ai.split.service.core.service;
 
 import com.split.ai.split.service.model.request.userauth.LoginRequest;
-import com.split.ai.split.service.model.request.userauth.LogoutRequest;
 import com.split.ai.split.service.model.request.userauth.SignupRequest;
 import com.split.ai.split.service.model.response.userauth.LoginResponse;
 import com.split.ai.split.service.model.response.userauth.SignupResponse;
@@ -12,5 +11,5 @@ public interface IUserAuthService {
 
     LoginResponse login(LoginRequest request);
 
-    void logout(LogoutRequest request);
+    void logout(String refreshToken);
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/TokenService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/TokenService.java
@@ -1,0 +1,122 @@
+package com.split.ai.split.service.core.service.impl;
+
+import com.split.ai.split.service.core.service.ITokenService;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenService implements ITokenService {
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${security.auth.access-token-secret}")
+    private String accessSecret;
+
+    @Value("${security.auth.refresh-token-secret}")
+    private String refreshSecret;
+
+    @Value("${security.auth.access-token-ttl}")
+    private long accessTtl;
+
+    @Value("${security.auth.refresh-token-ttl}")
+    private long refreshTtl;
+
+    private String sign(String data, String secret) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            byte[] sig = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(sig);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String encode(Map<String, Object> payload, String secret) {
+        try {
+            String headerJson = objectMapper.writeValueAsString(Map.of("alg", "HS256", "typ", "JWT"));
+            String payloadJson = objectMapper.writeValueAsString(payload);
+            String header = Base64.getUrlEncoder().withoutPadding().encodeToString(headerJson.getBytes(StandardCharsets.UTF_8));
+            String body = Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
+            String signature = sign(header + "." + body, secret);
+            return header + "." + body + "." + signature;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Map<String, Object> decode(String token, String secret) {
+        try {
+            String[] parts = token.split("\\.");
+            if (parts.length != 3) {
+                throw new IllegalArgumentException("Invalid token");
+            }
+            String sig = sign(parts[0] + "." + parts[1], secret);
+            if (!sig.equals(parts[2])) {
+                throw new IllegalArgumentException("Invalid token signature");
+            }
+            byte[] json = Base64.getUrlDecoder().decode(parts[1]);
+            Map<String, Object> payload = objectMapper.readValue(json, MAP_TYPE);
+            long exp = ((Number) payload.get("exp")).longValue();
+            if (exp < System.currentTimeMillis()) {
+                throw new IllegalArgumentException("Token expired");
+            }
+            return payload;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String generateAccessToken(UUID userId, UUID sessionId, int tokenVersion) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("sub", userId.toString());
+        payload.put("sid", sessionId.toString());
+        payload.put("tv", tokenVersion);
+        payload.put("exp", System.currentTimeMillis() + accessTtl);
+        return encode(payload, accessSecret);
+    }
+
+    @Override
+    public String generateRefreshToken(UUID refreshTokenId, UUID userId, UUID sessionId, int tokenVersion) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("jti", refreshTokenId.toString());
+        payload.put("sub", userId.toString());
+        payload.put("sid", sessionId.toString());
+        payload.put("tv", tokenVersion);
+        payload.put("exp", System.currentTimeMillis() + refreshTtl);
+        return encode(payload, refreshSecret);
+    }
+
+    @Override
+    public Map<String, Object> parseAccessToken(String token) {
+        return decode(token, accessSecret);
+    }
+
+    @Override
+    public Map<String, Object> parseRefreshToken(String token) {
+        return decode(token, refreshSecret);
+    }
+
+    @Override
+    public String hashToken(String token) {
+        return sign(token, refreshSecret);
+    }
+}
+

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/UserAuthService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/UserAuthService.java
@@ -4,16 +4,23 @@ import com.split.ai.split.service.commons.exception.ErrorCode;
 import com.split.ai.split.service.commons.exception.SplitException;
 import com.split.ai.split.service.core.mapper.UserAuthServiceMapper;
 import com.split.ai.split.service.core.service.IPasswordService;
+import com.split.ai.split.service.core.service.ITokenService;
 import com.split.ai.split.service.core.service.IUserAuthService;
 import com.split.ai.split.service.model.request.userauth.LoginRequest;
-import com.split.ai.split.service.model.request.userauth.LogoutRequest;
 import com.split.ai.split.service.model.request.userauth.SignupRequest;
 import com.split.ai.split.service.model.response.userauth.LoginResponse;
 import com.split.ai.split.service.model.response.userauth.SignupResponse;
 import com.split.ai.split.service.repository.dao.IIdentityDao;
 import com.split.ai.split.service.repository.dao.ILocalCredentialsDao;
+import com.split.ai.split.service.repository.dao.IRefreshTokenDao;
+import com.split.ai.split.service.repository.dao.ISessionDao;
+import com.split.ai.split.service.repository.dao.IUserDao;
 import com.split.ai.split.service.repository.entity.IdentityEntity;
 import com.split.ai.split.service.repository.entity.LocalCredentialsEntity;
+import com.split.ai.split.service.repository.entity.RefreshTokenEntity;
+import com.split.ai.split.service.repository.entity.SessionEntity;
+import com.split.ai.split.service.repository.entity.UserEntity;
+import com.split.ai.split.service.model.enums.USER_STATUS;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,6 +28,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -29,10 +37,17 @@ public class UserAuthService implements IUserAuthService {
 
     private final IIdentityDao identityDao;
     private final ILocalCredentialsDao localCredentialsDao;
+    private final IRefreshTokenDao refreshTokenDao;
+    private final ISessionDao sessionDao;
+    private final IUserDao userDao;
     private final IPasswordService passwordService;
+    private final ITokenService tokenService;
 
     @Value("${security.password.hash-algo}")
     private String hashAlgo;
+
+    @Value("${security.auth.refresh-token-ttl}")
+    private long refreshTtl;
 
     public SignupResponse signup(SignupRequest request) {
         log.info("[UserAuthService : signup] : userName={}", request.getUserName());
@@ -44,7 +59,9 @@ public class UserAuthService implements IUserAuthService {
         LocalCredentialsEntity credentialsEntity = UserAuthServiceMapper.MAPPER.toLocalCredentialsEntity(userId, encodedPassword, hashAlgo);
         localCredentialsDao.save(credentialsEntity);
 
-        return UserAuthServiceMapper.MAPPER.toSignupResponse(request, userId);
+        SignupResponse response = UserAuthServiceMapper.MAPPER.toSignupResponse(request, userId);
+        attachTokens(userId, 0, response);
+        return response;
     }
 
     public LoginResponse login(LoginRequest request) {
@@ -69,11 +86,69 @@ public class UserAuthService implements IUserAuthService {
             throw SplitException.createException(ErrorCode.INVALID_CREDENTIALS);
         }
 
-        return UserAuthServiceMapper.MAPPER.toLoginResponse(identityEntity);
+        UserEntity userEntity = userDao.findById(identityEntity.getUserId());
+        if (userEntity.getUserStatus() == USER_STATUS.BLOCKED) {
+            log.error("[UserAuthService : login] : user blocked {}", userEntity.getUserId());
+            throw SplitException.createException(ErrorCode.INVALID_CREDENTIALS);
+        }
+        LoginResponse response = UserAuthServiceMapper.MAPPER.toLoginResponse(identityEntity);
+        attachTokens(userEntity.getUserId(), userEntity.getTokenVersion(), response);
+        return response;
     }
 
-    // todo
-    public void logout(LogoutRequest request) {
-        log.info("[UserAuthService : logout] : noop");
+
+    public void logout(String refreshToken) {
+        if (refreshToken == null) {
+            return;
+        }
+        try {
+            Map<String, Object> claims = tokenService.parseRefreshToken(refreshToken);
+            UUID tokenId = UUID.fromString((String) claims.get("jti"));
+            refreshTokenDao.findById(tokenId).ifPresent(rt -> {
+                rt.setRevokedAt(System.currentTimeMillis());
+                refreshTokenDao.update(rt);
+                sessionDao.findById(rt.getSessionId()).ifPresent(sess -> {
+                    sess.setRevokedAt(System.currentTimeMillis());
+                    sessionDao.update(sess);
+                });
+            });
+        } catch (Exception e) {
+            log.error("[UserAuthService : logout] : failed", e);
+        }
     }
+
+    private void attachTokens(UUID userId, int tokenVersion, SignupResponse response) {
+        Tokens tokens = createTokens(userId, tokenVersion);
+        response.setAccessToken(tokens.accessToken);
+        response.setRefreshToken(tokens.refreshToken);
+    }
+
+    private void attachTokens(UUID userId, int tokenVersion, LoginResponse response) {
+        Tokens tokens = createTokens(userId, tokenVersion);
+        response.setAccessToken(tokens.accessToken);
+        response.setRefreshToken(tokens.refreshToken);
+    }
+
+    private Tokens createTokens(UUID userId, int tokenVersion) {
+        UUID sessionId = UUID.randomUUID();
+        sessionDao.save(SessionEntity.builder().sessionId(sessionId).userId(userId).build());
+
+        UUID refreshTokenId = UUID.randomUUID();
+        String refreshToken = tokenService.generateRefreshToken(refreshTokenId, userId, sessionId, tokenVersion);
+        long now = System.currentTimeMillis();
+        RefreshTokenEntity refreshEntity = RefreshTokenEntity.builder()
+                .refreshTokenId(refreshTokenId)
+                .userId(userId)
+                .sessionId(sessionId)
+                .tokenHash(tokenService.hashToken(refreshToken))
+                .issuedAt(now)
+                .expiresAt(now + refreshTtl)
+                .build();
+        refreshTokenDao.save(refreshEntity);
+
+        String accessToken = tokenService.generateAccessToken(userId, sessionId, tokenVersion);
+        return new Tokens(accessToken, refreshToken);
+    }
+
+    private record Tokens(String accessToken, String refreshToken) {}
 }

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/enums/USER_STATUS.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/enums/USER_STATUS.java
@@ -4,5 +4,5 @@ public enum USER_STATUS {
     PENDING_VERIFICATION,
     ACTIVE,
     IN_ACTIVE,
-    ;
+    BLOCKED;
 }

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/userauth/LoginResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/userauth/LoginResponse.java
@@ -1,6 +1,7 @@
 package com.split.ai.split.service.model.response.userauth;
 
 import java.util.UUID;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,4 +15,8 @@ public class LoginResponse {
 
     private UUID userId;
     private String userName;
+    @JsonIgnore
+    private String accessToken;
+    @JsonIgnore
+    private String refreshToken;
 }

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/userauth/SignupResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/userauth/SignupResponse.java
@@ -1,6 +1,7 @@
 package com.split.ai.split.service.model.response.userauth;
 
 import java.util.UUID;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,4 +15,8 @@ public class SignupResponse {
 
     private UUID userId;
     private String userName;
+    @JsonIgnore
+    private String accessToken;
+    @JsonIgnore
+    private String refreshToken;
 }

--- a/split-service-server/src/main/java/com/split/ai/split/service/server/controller/UserAuthController.java
+++ b/split-service-server/src/main/java/com/split/ai/split/service/server/controller/UserAuthController.java
@@ -2,17 +2,20 @@ package com.split.ai.split.service.server.controller;
 
 import com.split.ai.split.service.core.service.IUserAuthService;
 import com.split.ai.split.service.model.request.userauth.LoginRequest;
-import com.split.ai.split.service.model.request.userauth.LogoutRequest;
 import com.split.ai.split.service.model.request.userauth.SignupRequest;
 import com.split.ai.split.service.model.response.userauth.LoginResponse;
 import com.split.ai.split.service.model.response.userauth.SignupResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Slf4j
 @RestController
@@ -23,20 +26,55 @@ public class UserAuthController {
     private final IUserAuthService userAuthService;
 
     @PostMapping("/signup")
-    public SignupResponse signup(@Valid @RequestBody SignupRequest request) {
+    public SignupResponse signup(@Valid @RequestBody SignupRequest request, HttpServletResponse response) {
         log.info("[UserAuthController : signup] : userName={}", request.getUserName());
-        return userAuthService.signup(request);
+        SignupResponse resp = userAuthService.signup(request);
+        setCookies(response, resp.getAccessToken(), resp.getRefreshToken());
+        return resp;
     }
 
     @PostMapping("/login")
-    public LoginResponse login(@Valid @RequestBody LoginRequest request) {
+    public LoginResponse login(@Valid @RequestBody LoginRequest request, HttpServletResponse response) {
         log.info("[UserAuthController : login] : identifier={}", request.getIdentifier());
-        return userAuthService.login(request);
+        LoginResponse resp = userAuthService.login(request);
+        setCookies(response, resp.getAccessToken(), resp.getRefreshToken());
+        return resp;
     }
 
     @PostMapping("/logout")
-    public void logout(@RequestBody LogoutRequest request) {
+    public void logout(@CookieValue(value = "RefreshToken", required = false) String refreshToken,
+                       HttpServletResponse response) {
         log.info("[UserAuthController : logout] : noop");
-        userAuthService.logout(request);
+        userAuthService.logout(refreshToken);
+        clearCookies(response);
+    }
+
+    private void setCookies(HttpServletResponse response, String accessToken, String refreshToken) {
+        if (accessToken == null || refreshToken == null) {
+            return;
+        }
+        ResponseCookie accessCookie = ResponseCookie.from("AccessToken", accessToken)
+                .httpOnly(true)
+                .path("/")
+                .build();
+        ResponseCookie refreshCookie = ResponseCookie.from("RefreshToken", refreshToken)
+                .httpOnly(true)
+                .path("/")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+    }
+
+    private void clearCookies(HttpServletResponse response) {
+        ResponseCookie accessCookie = ResponseCookie.from("AccessToken", "")
+                .path("/")
+                .maxAge(0)
+                .build();
+        ResponseCookie refreshCookie = ResponseCookie.from("RefreshToken", "")
+                .path("/")
+                .maxAge(0)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
     }
 }

--- a/split-service-server/src/main/java/com/split/ai/split/service/server/filter/AuthenticationFilter.java
+++ b/split-service-server/src/main/java/com/split/ai/split/service/server/filter/AuthenticationFilter.java
@@ -1,0 +1,181 @@
+package com.split.ai.split.service.server.filter;
+
+import com.split.ai.split.service.core.service.ITokenService;
+import com.split.ai.split.service.repository.dao.IRefreshTokenDao;
+import com.split.ai.split.service.repository.dao.ISessionDao;
+import com.split.ai.split.service.repository.dao.IUserDao;
+import com.split.ai.split.service.repository.entity.RefreshTokenEntity;
+import com.split.ai.split.service.repository.entity.SessionEntity;
+import com.split.ai.split.service.repository.entity.UserEntity;
+import com.split.ai.split.service.model.enums.USER_STATUS;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthenticationFilter extends OncePerRequestFilter {
+
+    private final ITokenService tokenService;
+    private final IRefreshTokenDao refreshTokenDao;
+    private final ISessionDao sessionDao;
+    private final IUserDao userDao;
+
+    @Value("${security.auth.session-max-age}")
+    private long sessionMaxAge;
+
+    @Value("${security.auth.access-token-refresh-before}")
+    private long accessRefreshBefore;
+
+    @Value("${security.auth.refresh-token-refresh-before}")
+    private long refreshRefreshBefore;
+
+    @Value("${security.auth.refresh-token-ttl}")
+    private long refreshTtl;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String accessToken = getCookie(request, "AccessToken");
+        String refreshToken = getCookie(request, "RefreshToken");
+
+        boolean authenticated = false;
+        if (accessToken != null) {
+            try {
+                Map<String, Object> claims = tokenService.parseAccessToken(accessToken);
+                UUID userId = UUID.fromString((String) claims.get("sub"));
+                UUID sessionId = UUID.fromString((String) claims.get("sid"));
+                int tokenVersion = (Integer) claims.get("tv");
+                long exp = ((Number) claims.get("exp")).longValue();
+                long now = System.currentTimeMillis();
+
+                SessionEntity session = sessionDao.findById(sessionId).orElse(null);
+                UserEntity user = userDao.findById(userId);
+
+                if (session != null && session.getRevokedAt() == null && user != null
+                        && user.getUserStatus() != USER_STATUS.BLOCKED && user.getTokenVersion() == tokenVersion
+                        && session.getCreatedAt() + sessionMaxAge > now) {
+                    session.setLastUsedAt(now);
+                    sessionDao.update(session);
+                    authenticated = true;
+                    if (refreshToken != null) {
+                        try {
+                            Map<String, Object> rtClaims = tokenService.parseRefreshToken(refreshToken);
+                            long rExp = ((Number) rtClaims.get("exp")).longValue();
+                            if ((exp - now) <= accessRefreshBefore || (rExp - now) <= refreshRefreshBefore) {
+                                rotateTokens(refreshToken, user, session, response);
+                            }
+                        } catch (Exception e) {
+                            // ignore and try refresh
+                        }
+                    } else if ((exp - now) <= accessRefreshBefore && refreshToken != null) {
+                        rotateTokens(refreshToken, user, session, response);
+                    }
+                }
+            } catch (Exception e) {
+                log.debug("[AuthenticationFilter] access token invalid, attempting refresh");
+            }
+        }
+
+        if (!authenticated && refreshToken != null) {
+            try {
+                Map<String, Object> rtClaims = tokenService.parseRefreshToken(refreshToken);
+                UUID userId = UUID.fromString((String) rtClaims.get("sub"));
+                UUID sessionId = UUID.fromString((String) rtClaims.get("sid"));
+                UserEntity user = userDao.findById(userId);
+                SessionEntity session = sessionDao.findById(sessionId).orElse(null);
+                rotateTokens(refreshToken, user, session, response);
+                authenticated = true;
+            } catch (Exception ex) {
+                clearCookies(response);
+            }
+        }
+
+        if (!authenticated && refreshToken == null && accessToken != null) {
+            clearCookies(response);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void rotateTokens(String refreshToken, UserEntity user, SessionEntity session, HttpServletResponse response) {
+        if (user == null || session == null) {
+            clearCookies(response);
+            return;
+        }
+        try {
+            Map<String, Object> rtClaims = tokenService.parseRefreshToken(refreshToken);
+            UUID tokenId = UUID.fromString((String) rtClaims.get("jti"));
+            long now = System.currentTimeMillis();
+            RefreshTokenEntity existing = refreshTokenDao.findById(tokenId).orElse(null);
+            if (existing == null || existing.getRevokedAt() != null
+                    || !existing.getTokenHash().equals(tokenService.hashToken(refreshToken))) {
+                clearCookies(response);
+                return;
+            }
+            UUID newRefreshId = UUID.randomUUID();
+            String newRefresh = tokenService.generateRefreshToken(newRefreshId, user.getUserId(), session.getSessionId(), user.getTokenVersion());
+            RefreshTokenEntity newEntity = RefreshTokenEntity.builder()
+                    .refreshTokenId(newRefreshId)
+                    .userId(user.getUserId())
+                    .sessionId(session.getSessionId())
+                    .tokenHash(tokenService.hashToken(newRefresh))
+                    .issuedAt(now)
+                    .expiresAt(now + refreshTtl)
+                    .build();
+            refreshTokenDao.save(newEntity);
+            existing.setRevokedAt(now);
+            existing.setReplacedBy(newRefreshId);
+            refreshTokenDao.update(existing);
+
+            String newAccess = tokenService.generateAccessToken(user.getUserId(), session.getSessionId(), user.getTokenVersion());
+            setCookies(response, newAccess, newRefresh);
+        } catch (Exception e) {
+            clearCookies(response);
+        }
+    }
+
+    private void setCookies(HttpServletResponse response, String accessToken, String refreshToken) {
+        ResponseCookie accessCookie = ResponseCookie.from("AccessToken", accessToken)
+                .httpOnly(true).path("/").build();
+        ResponseCookie refreshCookie = ResponseCookie.from("RefreshToken", refreshToken)
+                .httpOnly(true).path("/").build();
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+    }
+
+    private void clearCookies(HttpServletResponse response) {
+        ResponseCookie accessCookie = ResponseCookie.from("AccessToken", "").path("/").maxAge(0).build();
+        ResponseCookie refreshCookie = ResponseCookie.from("RefreshToken", "").path("/").maxAge(0).build();
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+    }
+
+    private String getCookie(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+        for (Cookie c : request.getCookies()) {
+            if (name.equals(c.getName())) {
+                return c.getValue();
+            }
+        }
+        return null;
+    }
+}
+

--- a/split-service-server/src/main/resources/application.yml
+++ b/split-service-server/src/main/resources/application.yml
@@ -9,4 +9,12 @@ security:
   password:
     pepper: ${PASSWORD_PEPPER:defaultPepper}
     hash-algo: argon2id
+  auth:
+    access-token-secret: ${ACCESS_TOKEN_SECRET:changeMeAccess}
+    refresh-token-secret: ${REFRESH_TOKEN_SECRET:changeMeRefresh}
+    access-token-ttl: ${ACCESS_TOKEN_TTL:900000} # 15 minutes
+    refresh-token-ttl: ${REFRESH_TOKEN_TTL:2592000000} # 30 days
+    session-max-age: ${SESSION_MAX_AGE:2592000000} # 30 days
+    access-token-refresh-before: ${ACCESS_TOKEN_REFRESH_BEFORE:60000} # 60 seconds
+    refresh-token-refresh-before: ${REFRESH_TOKEN_REFRESH_BEFORE:86400000} # 24 hours
 


### PR DESCRIPTION
## Summary
- issue HMAC-signed access and refresh tokens during signup and login
- authenticate and rotate tokens with a request filter
- persist sessions and refresh tokens with configurable TTLs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bf160001948322b3dba49f72d65f5f