### PR TITLE
feat(auth): handle tokens via helper

### DIFF
--- a/split-service-core/src/main/java/com/split/ai/split/service/core/helper/TokenHelper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/helper/TokenHelper.java
@@ -1,0 +1,92 @@
+package com.split.ai.split.service.core.helper;
+
+import com.split.ai.split.service.core.service.ITokenService;
+import com.split.ai.split.service.repository.dao.IRefreshTokenDao;
+import com.split.ai.split.service.repository.dao.ISessionDao;
+import com.split.ai.split.service.repository.entity.RefreshTokenEntity;
+import com.split.ai.split.service.repository.entity.SessionEntity;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class TokenHelper {
+
+    private final ISessionDao sessionDao;
+    private final IRefreshTokenDao refreshTokenDao;
+    private final ITokenService tokenService;
+
+    @Value("${security.auth.refresh-token-ttl}")
+    private long refreshTtl;
+
+    public Tokens createTokens(UUID userId, int tokenVersion) {
+        UUID sessionId = UUID.randomUUID();
+        sessionDao.save(SessionEntity.builder().sessionId(sessionId).userId(userId).build());
+
+        UUID refreshTokenId = UUID.randomUUID();
+        String refreshToken = tokenService.generateRefreshToken(refreshTokenId, userId, sessionId, tokenVersion);
+        long now = System.currentTimeMillis();
+        RefreshTokenEntity refreshEntity = RefreshTokenEntity.builder()
+                .refreshTokenId(refreshTokenId)
+                .userId(userId)
+                .sessionId(sessionId)
+                .tokenHash(tokenService.hashToken(refreshToken))
+                .issuedAt(now)
+                .expiresAt(now + refreshTtl)
+                .build();
+        refreshTokenDao.save(refreshEntity);
+
+        String accessToken = tokenService.generateAccessToken(userId, sessionId, tokenVersion);
+        return new Tokens(accessToken, refreshToken);
+    }
+
+    public void setCookies(HttpServletResponse response, Tokens tokens) {
+        ResponseCookie accessCookie = ResponseCookie.from("AccessToken", tokens.accessToken())
+                .httpOnly(true).path("/").build();
+        ResponseCookie refreshCookie = ResponseCookie.from("RefreshToken", tokens.refreshToken())
+                .httpOnly(true).path("/").build();
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+    }
+
+    public void clearCookies(HttpServletResponse response) {
+        ResponseCookie accessCookie = ResponseCookie.from("AccessToken", "")
+                .path("/").maxAge(0).build();
+        ResponseCookie refreshCookie = ResponseCookie.from("RefreshToken", "")
+                .path("/").maxAge(0).build();
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+    }
+
+    public String getAccessToken(HttpServletRequest request) {
+        return getCookie(request, "AccessToken");
+    }
+
+    public String getRefreshToken(HttpServletRequest request) {
+        return getCookie(request, "RefreshToken");
+    }
+
+    private String getCookie(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+        for (Cookie c : request.getCookies()) {
+            if (name.equals(c.getName())) {
+                return c.getValue();
+            }
+        }
+        return null;
+    }
+
+    public record Tokens(String accessToken, String refreshToken) {
+    }
+}
+

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/UserAuthServiceMapper.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/mapper/UserAuthServiceMapper.java
@@ -18,13 +18,9 @@ public interface UserAuthServiceMapper extends BaseServiceMapper {
 
     @Mapping(target = "userId", source = "userId")
     @Mapping(target = "userName", source = "request.userName")
-    @Mapping(target = "accessToken", ignore = true)
-    @Mapping(target = "refreshToken", ignore = true)
     SignupResponse toSignupResponse(SignupRequest request, UUID userId);
 
     @Mapping(target = "userName", source = "identifier")
-    @Mapping(target = "accessToken", ignore = true)
-    @Mapping(target = "refreshToken", ignore = true)
     LoginResponse toLoginResponse(IdentityEntity identityEntity);
 
     @Mapping(target = "identityId", source = "request", qualifiedByName = "randomUUID")

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/IUserAuthService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/IUserAuthService.java
@@ -4,12 +4,14 @@ import com.split.ai.split.service.model.request.userauth.LoginRequest;
 import com.split.ai.split.service.model.request.userauth.SignupRequest;
 import com.split.ai.split.service.model.response.userauth.LoginResponse;
 import com.split.ai.split.service.model.response.userauth.SignupResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface IUserAuthService {
 
-    SignupResponse signup(SignupRequest request);
+    SignupResponse signup(SignupRequest request, HttpServletResponse response);
 
-    LoginResponse login(LoginRequest request);
+    LoginResponse login(LoginRequest request, HttpServletResponse response);
 
-    void logout(String refreshToken);
+    void logout(HttpServletRequest request, HttpServletResponse response);
 }

--- a/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/UserAuthService.java
+++ b/split-service-core/src/main/java/com/split/ai/split/service/core/service/impl/UserAuthService.java
@@ -3,6 +3,8 @@ package com.split.ai.split.service.core.service.impl;
 import com.split.ai.split.service.commons.exception.ErrorCode;
 import com.split.ai.split.service.commons.exception.SplitException;
 import com.split.ai.split.service.core.mapper.UserAuthServiceMapper;
+import com.split.ai.split.service.core.helper.TokenHelper;
+import com.split.ai.split.service.core.helper.TokenHelper.Tokens;
 import com.split.ai.split.service.core.service.IPasswordService;
 import com.split.ai.split.service.core.service.ITokenService;
 import com.split.ai.split.service.core.service.IUserAuthService;
@@ -21,6 +23,9 @@ import com.split.ai.split.service.repository.entity.RefreshTokenEntity;
 import com.split.ai.split.service.repository.entity.SessionEntity;
 import com.split.ai.split.service.repository.entity.UserEntity;
 import com.split.ai.split.service.model.enums.USER_STATUS;
+import com.split.ai.split.service.model.enums.LANGUAGE;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -42,14 +47,12 @@ public class UserAuthService implements IUserAuthService {
     private final IUserDao userDao;
     private final IPasswordService passwordService;
     private final ITokenService tokenService;
+    private final TokenHelper tokenHelper;
 
     @Value("${security.password.hash-algo}")
     private String hashAlgo;
 
-    @Value("${security.auth.refresh-token-ttl}")
-    private long refreshTtl;
-
-    public SignupResponse signup(SignupRequest request) {
+    public SignupResponse signup(SignupRequest request, HttpServletResponse httpResponse) {
         log.info("[UserAuthService : signup] : userName={}", request.getUserName());
         IdentityEntity identityEntity = UserAuthServiceMapper.MAPPER.toIdentityEntity(request, Boolean.FALSE);
         UUID userId = identityEntity.getUserId();
@@ -59,12 +62,26 @@ public class UserAuthService implements IUserAuthService {
         LocalCredentialsEntity credentialsEntity = UserAuthServiceMapper.MAPPER.toLocalCredentialsEntity(userId, encodedPassword, hashAlgo);
         localCredentialsDao.save(credentialsEntity);
 
+        UserEntity userEntity = UserEntity.builder()
+                .userId(userId)
+                .fullName(request.getUserName())
+                .userName(request.getUserName())
+                .emailId(request.getEmailId())
+                .phone("")
+                .userStatus(USER_STATUS.ACTIVE)
+                .language(LANGUAGE.ENGLISH)
+                .tokenVersion(0)
+                .build();
+        userEntity.beforeInsertOrUpdate();
+        userDao.save(userEntity);
+
         SignupResponse response = UserAuthServiceMapper.MAPPER.toSignupResponse(request, userId);
-        attachTokens(userId, 0, response);
+        Tokens tokens = tokenHelper.createTokens(userId, userEntity.getTokenVersion());
+        tokenHelper.setCookies(httpResponse, tokens);
         return response;
     }
 
-    public LoginResponse login(LoginRequest request) {
+    public LoginResponse login(LoginRequest request, HttpServletResponse httpResponse) {
         log.info("[UserAuthService : login] : identifier={}", request.getIdentifier());
         Optional<IdentityEntity> identityOpt = identityDao.findByProviderAndIdentifier(request.getProvider(), request.getIdentifier());
         IdentityEntity identityEntity = identityOpt.orElseThrow(() -> {
@@ -92,63 +109,33 @@ public class UserAuthService implements IUserAuthService {
             throw SplitException.createException(ErrorCode.INVALID_CREDENTIALS);
         }
         LoginResponse response = UserAuthServiceMapper.MAPPER.toLoginResponse(identityEntity);
-        attachTokens(userEntity.getUserId(), userEntity.getTokenVersion(), response);
+        Tokens tokens = tokenHelper.createTokens(userEntity.getUserId(), userEntity.getTokenVersion());
+        tokenHelper.setCookies(httpResponse, tokens);
         return response;
     }
 
-
-    public void logout(String refreshToken) {
+    public void logout(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
+        String refreshToken = tokenHelper.getRefreshToken(httpRequest);
+        tokenHelper.clearCookies(httpResponse);
         if (refreshToken == null) {
             return;
         }
         try {
             Map<String, Object> claims = tokenService.parseRefreshToken(refreshToken);
             UUID tokenId = UUID.fromString((String) claims.get("jti"));
-            refreshTokenDao.findById(tokenId).ifPresent(rt -> {
-                rt.setRevokedAt(System.currentTimeMillis());
-                refreshTokenDao.update(rt);
-                sessionDao.findById(rt.getSessionId()).ifPresent(sess -> {
-                    sess.setRevokedAt(System.currentTimeMillis());
-                    sessionDao.update(sess);
-                });
-            });
+            RefreshTokenEntity rt = refreshTokenDao.findById(tokenId)
+                    .orElseThrow(() -> SplitException.createException(ErrorCode.INVALID_CREDENTIALS));
+            SessionEntity sess = sessionDao.findById(rt.getSessionId())
+                    .orElseThrow(() -> SplitException.createException(ErrorCode.INVALID_CREDENTIALS));
+            rt.setRevokedAt(System.currentTimeMillis());
+            refreshTokenDao.update(rt);
+            sess.setRevokedAt(System.currentTimeMillis());
+            sessionDao.update(sess);
+        } catch (SplitException e) {
+            throw e;
         } catch (Exception e) {
             log.error("[UserAuthService : logout] : failed", e);
+            throw SplitException.createException(ErrorCode.INVALID_CREDENTIALS);
         }
     }
-
-    private void attachTokens(UUID userId, int tokenVersion, SignupResponse response) {
-        Tokens tokens = createTokens(userId, tokenVersion);
-        response.setAccessToken(tokens.accessToken);
-        response.setRefreshToken(tokens.refreshToken);
-    }
-
-    private void attachTokens(UUID userId, int tokenVersion, LoginResponse response) {
-        Tokens tokens = createTokens(userId, tokenVersion);
-        response.setAccessToken(tokens.accessToken);
-        response.setRefreshToken(tokens.refreshToken);
-    }
-
-    private Tokens createTokens(UUID userId, int tokenVersion) {
-        UUID sessionId = UUID.randomUUID();
-        sessionDao.save(SessionEntity.builder().sessionId(sessionId).userId(userId).build());
-
-        UUID refreshTokenId = UUID.randomUUID();
-        String refreshToken = tokenService.generateRefreshToken(refreshTokenId, userId, sessionId, tokenVersion);
-        long now = System.currentTimeMillis();
-        RefreshTokenEntity refreshEntity = RefreshTokenEntity.builder()
-                .refreshTokenId(refreshTokenId)
-                .userId(userId)
-                .sessionId(sessionId)
-                .tokenHash(tokenService.hashToken(refreshToken))
-                .issuedAt(now)
-                .expiresAt(now + refreshTtl)
-                .build();
-        refreshTokenDao.save(refreshEntity);
-
-        String accessToken = tokenService.generateAccessToken(userId, sessionId, tokenVersion);
-        return new Tokens(accessToken, refreshToken);
-    }
-
-    private record Tokens(String accessToken, String refreshToken) {}
 }

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/userauth/LoginResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/userauth/LoginResponse.java
@@ -1,7 +1,6 @@
 package com.split.ai.split.service.model.response.userauth;
 
 import java.util.UUID;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,8 +14,4 @@ public class LoginResponse {
 
     private UUID userId;
     private String userName;
-    @JsonIgnore
-    private String accessToken;
-    @JsonIgnore
-    private String refreshToken;
 }

--- a/split-service-model/src/main/java/com/split/ai/split/service/model/response/userauth/SignupResponse.java
+++ b/split-service-model/src/main/java/com/split/ai/split/service/model/response/userauth/SignupResponse.java
@@ -1,7 +1,6 @@
 package com.split.ai.split.service.model.response.userauth;
 
 import java.util.UUID;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,8 +14,4 @@ public class SignupResponse {
 
     private UUID userId;
     private String userName;
-    @JsonIgnore
-    private String accessToken;
-    @JsonIgnore
-    private String refreshToken;
 }

--- a/split-service-server/src/main/java/com/split/ai/split/service/server/controller/UserAuthController.java
+++ b/split-service-server/src/main/java/com/split/ai/split/service/server/controller/UserAuthController.java
@@ -5,17 +5,15 @@ import com.split.ai.split.service.model.request.userauth.LoginRequest;
 import com.split.ai.split.service.model.request.userauth.SignupRequest;
 import com.split.ai.split.service.model.response.userauth.LoginResponse;
 import com.split.ai.split.service.model.response.userauth.SignupResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import jakarta.servlet.http.HttpServletResponse;
 
 @Slf4j
 @RestController
@@ -28,53 +26,18 @@ public class UserAuthController {
     @PostMapping("/signup")
     public SignupResponse signup(@Valid @RequestBody SignupRequest request, HttpServletResponse response) {
         log.info("[UserAuthController : signup] : userName={}", request.getUserName());
-        SignupResponse resp = userAuthService.signup(request);
-        setCookies(response, resp.getAccessToken(), resp.getRefreshToken());
-        return resp;
+        return userAuthService.signup(request, response);
     }
 
     @PostMapping("/login")
     public LoginResponse login(@Valid @RequestBody LoginRequest request, HttpServletResponse response) {
         log.info("[UserAuthController : login] : identifier={}", request.getIdentifier());
-        LoginResponse resp = userAuthService.login(request);
-        setCookies(response, resp.getAccessToken(), resp.getRefreshToken());
-        return resp;
+        return userAuthService.login(request, response);
     }
 
     @PostMapping("/logout")
-    public void logout(@CookieValue(value = "RefreshToken", required = false) String refreshToken,
-                       HttpServletResponse response) {
+    public void logout(HttpServletRequest request, HttpServletResponse response) {
         log.info("[UserAuthController : logout] : noop");
-        userAuthService.logout(refreshToken);
-        clearCookies(response);
-    }
-
-    private void setCookies(HttpServletResponse response, String accessToken, String refreshToken) {
-        if (accessToken == null || refreshToken == null) {
-            return;
-        }
-        ResponseCookie accessCookie = ResponseCookie.from("AccessToken", accessToken)
-                .httpOnly(true)
-                .path("/")
-                .build();
-        ResponseCookie refreshCookie = ResponseCookie.from("RefreshToken", refreshToken)
-                .httpOnly(true)
-                .path("/")
-                .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
-    }
-
-    private void clearCookies(HttpServletResponse response) {
-        ResponseCookie accessCookie = ResponseCookie.from("AccessToken", "")
-                .path("/")
-                .maxAge(0)
-                .build();
-        ResponseCookie refreshCookie = ResponseCookie.from("RefreshToken", "")
-                .path("/")
-                .maxAge(0)
-                .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+        userAuthService.logout(request, response);
     }
 }


### PR DESCRIPTION
## Summary
- manage token creation and cookies via new TokenHelper
- save user entity and set tokens with version
- simplify auth controller and validate refresh token session

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c05060e69883228262bd872ad3c930