### PR TITLE
fix: add BouncyCastle dependency for Argon2 encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,13 @@
             <artifactId>spring-security-crypto</artifactId>
         </dependency>
 
+        <!-- Argon2 support -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.78.1</version>
+        </dependency>
+
         <!-- Lombok – compile-only -->
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
## Summary
- add bcprov-jdk18on to supply Argon2Parameters for Argon2 password encoder

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c316c8b0608322a1925a80b4eec7d4